### PR TITLE
fix: update readme and change logic for checking home directory & user config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1087,6 +1087,7 @@ dependencies = [
  "futures",
  "hashbrown 0.15.0",
  "hex_color",
+ "homedir",
  "log",
  "macos-trampoline",
  "mimalloc",
@@ -2013,6 +2014,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "homedir"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bdbbd5bc8c5749697ccaa352fa45aff8730cf21c68029c0eef1ffed7c3d6ba2"
+dependencies = [
+ "cfg-if",
+ "nix",
+ "widestring",
+ "windows 0.57.0",
+]
+
+[[package]]
 name = "html5ever"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2702,6 +2715,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
  "smallvec",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -5676,6 +5701,12 @@ name = "weezl"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53a85b86a771b1c87058196170769dd264f66c0782acf1ae6cc51bfd64b39082"
+
+[[package]]
+name = "widestring"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7219d36b6eac893fa81e84ebe06485e7dcbb616177469b142df14f1f4deb1311"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,3 +108,4 @@ dyn-clone = "1.0.17"
 
 hecs = "0.10.5"
 hecs-hierarchy = "0.12.1"
+homedir = "0.3.4"

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ sudo apt install libsoup-3.0-dev
 sudo apt install clang
 ```
 
+**Note for Windows users:**
+
+You need to first install GNU make before running the `make` scripts:
+
+1. Install Chocolatey from https://chocolatey.org/install
+
+2. In an administrative shell, run `choco install make`
+
+Now you should be free to go!
+
 <!-- ## Nix usage (not ready to be used!)
 
 Before starting the project, ensure you have [NIX](https://nixos.org/download/) installed and enable the [flakes](https://nixos.wiki/wiki/Flakes) experimental feature.

--- a/internal/platform/configuration/src/user_settings.rs
+++ b/internal/platform/configuration/src/user_settings.rs
@@ -29,9 +29,15 @@ impl<'a> UserSettings {
     }
 
     pub fn load_configuration(&self, ctx: &mut Context) -> Result<ConfigurationModel> {
-        let mut file = ctx.block_on_with(self.fs_service.read_file(&self.resource))?;
+        // When the file doesn't exist, the code should not panic
+        // Instead, it should treat it as if the config file is empty
+        let mut file = ctx.block_on_with(self.fs_service.read_file(&self.resource));
         let mut content = String::new();
-        file.read_to_string(&mut content)?;
+
+        match file {
+            Ok(ref mut file) => {file.read_to_string(&mut content)?;},
+            Err(_) => {content = String::from("{}");}
+        }
 
         if content.trim().is_empty() {
             content = String::from("{}")

--- a/internal/platform/configuration/src/user_settings.rs
+++ b/internal/platform/configuration/src/user_settings.rs
@@ -29,8 +29,6 @@ impl<'a> UserSettings {
     }
 
     pub fn load_configuration(&self, ctx: &mut Context) -> Result<ConfigurationModel> {
-        // When the file doesn't exist, the code should not panic
-        // Instead, it should treat it as if the config file is empty
         let mut file = ctx.block_on_with(self.fs_service.read_file(&self.resource));
         let mut content = String::new();
 

--- a/view/desktop/bin/Cargo.toml
+++ b/view/desktop/bin/Cargo.toml
@@ -20,6 +20,7 @@ hex_color = "3.0.0"
 log = "0.4.21"
 rand = "0.8.5"
 fern = "0.7.0"
+homedir = "0.3.4"
 
 moss_base.workspace = true
 

--- a/view/desktop/bin/Cargo.toml
+++ b/view/desktop/bin/Cargo.toml
@@ -20,7 +20,6 @@ hex_color = "3.0.0"
 log = "0.4.21"
 rand = "0.8.5"
 fern = "0.7.0"
-homedir = "0.3.4"
 
 moss_base.workspace = true
 
@@ -33,6 +32,7 @@ tracing.workspace = true
 tracing-subscriber.workspace = true
 flume.workspace = true
 async-task.workspace = true
+homedir.workspace = true
 
 platform_core.workspace = true
 platform_workspace.workspace = true

--- a/view/desktop/bin/src/commands/cmd_dummy.rs
+++ b/view/desktop/bin/src/commands/cmd_dummy.rs
@@ -6,6 +6,7 @@ use tauri::{AppHandle, Manager, State};
 use workbench_desktop::WorkbenchState;
 
 use crate::AppState;
+use crate::utl::get_home_dir;
 
 #[tauri::command(async)]
 #[specta::specta]
@@ -20,13 +21,7 @@ pub async fn fetch_all_themes() -> Result<Vec<String>, String> {
 #[tauri::command(async)]
 #[specta::specta]
 pub async fn read_theme(theme_name: String) -> Result<String, String> {
-    let home_dir = if cfg!(target_family = "unix") {
-        PathBuf::from(std::env::var("HOME").unwrap())
-    } else {
-        my_home()
-            .unwrap()
-            .expect("Failed to retrieve the home directory")
-    };
+    let home_dir = get_home_dir()?;
     let theme_file_path = home_dir
         .join(".config")
         .join("moss")

--- a/view/desktop/bin/src/commands/cmd_dummy.rs
+++ b/view/desktop/bin/src/commands/cmd_dummy.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use platform_core::context_v2::async_context::AsyncContext;
 use std::path::PathBuf;
+use homedir::my_home;
 use tauri::{AppHandle, Manager, State};
 use workbench_desktop::WorkbenchState;
 
@@ -19,7 +20,14 @@ pub async fn fetch_all_themes() -> Result<Vec<String>, String> {
 #[tauri::command(async)]
 #[specta::specta]
 pub async fn read_theme(theme_name: String) -> Result<String, String> {
-    let theme_file_path = PathBuf::from(std::env::var("HOME").unwrap())
+    let home_dir = if cfg!(target_family = "unix") {
+        PathBuf::from(std::env::var("HOME").unwrap())
+    } else {
+        my_home()
+            .unwrap()
+            .expect("Failed to retrieve the home directory")
+    };
+    let theme_file_path = home_dir
         .join(".config")
         .join("moss")
         .join("themes")

--- a/view/desktop/bin/src/lib.rs
+++ b/view/desktop/bin/src/lib.rs
@@ -81,10 +81,7 @@ pub fn run() {
     builder
         .setup(|app| {
             let platform_info = NativePlatformInfo::new();
-            // Windows does not use the "HOME" environmental variable
-            // Better to switch to a more platform-independent method
-            let home_dir = if cfg!(target_os = "unix") {
-                // homedir does not handle unix very well
+            let home_dir = if cfg!(target_family = "unix") {
                 PathBuf::from(env::var("HOME").unwrap())
             } else {
                 my_home()

--- a/view/desktop/bin/src/lib.rs
+++ b/view/desktop/bin/src/lib.rs
@@ -26,6 +26,7 @@ use workbench_desktop::Workbench;
 use crate::commands::*;
 use crate::constants::*;
 use crate::plugins as moss_plugins;
+use crate::utl::get_home_dir;
 
 #[macro_use]
 extern crate serde;
@@ -81,13 +82,7 @@ pub fn run() {
     builder
         .setup(|app| {
             let platform_info = NativePlatformInfo::new();
-            let home_dir = if cfg!(target_family = "unix") {
-                PathBuf::from(env::var("HOME").unwrap())
-            } else {
-                my_home()
-                    .unwrap()
-                    .expect("Failed to retrieve the home directory")
-            };
+            let home_dir = get_home_dir()?;
 
             let service_group = utl::create_service_registry(NativeWindowConfiguration {
                 home_dir,

--- a/view/desktop/bin/src/utl.rs
+++ b/view/desktop/bin/src/utl.rs
@@ -1,6 +1,8 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use anyhow::Result;
+use homedir::my_home;
 use platform_formation::service_registry::ServiceRegistry;
 use platform_fs::disk::file_system_service::DiskFileSystemService;
 use workbench_desktop::window::NativeWindowConfiguration;
@@ -30,4 +32,39 @@ pub fn create_service_registry(
     service_registry.insert(Arc::new(fs_service));
 
     Ok(service_registry)
+}
+
+pub fn get_home_dir() -> Result<PathBuf, String> {
+    #[cfg(target_os = "windows")]
+    {
+        windows_home_dir()
+    }
+
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    {
+        unix_home_dir()
+    }
+
+    #[cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))]
+    {
+        Err("Unsupported operating system".to_string())
+    }
+}
+
+/// Retrieves the home directory on Unix-like systems (macOS and Linux).
+#[cfg(any(target_os = "macos", target_os = "linux"))]
+fn unix_home_dir() -> Result<PathBuf, String> {
+    std::env::var("HOME")
+        .map(PathBuf::from)
+        .map_err(|e| format!("Failed to retrieve HOME environment variable: {}", e))
+}
+
+
+/// Retrieves the home directory on Windows.
+#[cfg(target_os = "windows")]
+fn windows_home_dir() -> Result<PathBuf, String> {
+    match my_home() {
+        Ok(result) => result.ok_or("Home directory not found".to_string()),
+        Err(e) => Err(format!("Failed to retrieve HOME directory: {}", e)),
+    }
 }


### PR DESCRIPTION
This PR contains 3 changes:

1. Update the readme with a section for Windows users on how to install GNU make, in order to use the makefile scripts
2. Use homedir rather than "HOME" env variable to check the home directory, making it more platform independent
3. The app will not panic when it cannot find the user config file: it will consider the config to be empty.