### PR TITLE
fix(MOSSMVP-234): Fix deadlock on clicking `New Window` button

### DIFF
--- a/view/desktop/bin/src/commands/cmd_window.rs
+++ b/view/desktop/bin/src/commands/cmd_window.rs
@@ -8,11 +8,13 @@ struct EventAData {
     data: String,
 }
 
+// According to https://docs.rs/tauri/2.1.1/tauri/webview/struct.WebviewWindowBuilder.html
+// We should call WebviewWindowBuilder from async commands
 #[tauri::command]
-pub fn create_new_window(parent_window: WebviewWindow) {
+pub async fn create_new_window(parent_window: WebviewWindow) {
     let app_handle = parent_window.app_handle().clone();
     create_child_window(
-        parent_window,
+        parent_window.label(),
         "/",
         &format!(
             "{OTHER_WINDOW_PREFIX}{}",
@@ -20,6 +22,7 @@ pub fn create_new_window(parent_window: WebviewWindow) {
         ),
         "Moss Studio",
         (DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT),
+        app_handle,
     )
     .expect("Failed to create new window");
 }

--- a/view/desktop/bin/src/lib.rs
+++ b/view/desktop/bin/src/lib.rs
@@ -161,10 +161,8 @@ fn create_main_window(handle: &AppHandle, url: &str) -> WebviewWindow {
         ),
     };
     let webview_window = create_window(handle, config);
-
-    let webview_window_clone = webview_window.clone();
     webview_window.on_menu_event(move |window, event| {
-        menu::handle_event(window, &webview_window_clone, &event)
+        menu::handle_event(window, label.as_str(), &event)
     });
 
     webview_window

--- a/view/desktop/bin/src/menu.rs
+++ b/view/desktop/bin/src/menu.rs
@@ -32,15 +32,17 @@ pub fn set_enabled(menu: &Menu<Wry>, event: &BuiltInMenuEvent, enabled: bool) ->
     }
 }
 
-pub fn handle_event(_window: &Window, webview: &WebviewWindow, event: &MenuEvent) {
+pub fn handle_event(_window: &Window, webview_label: &str, event: &MenuEvent) {
     let event_id = event.id().0.as_str();
+    let app_handle = _window.app_handle().clone();
     match event_id {
         "file.newWindow" => create_child_window(
-            webview.clone(),
+            webview_label,
             "/",
-            &format!("{OTHER_WINDOW_PREFIX}{}", webview.webview_windows().len()),
+            &format!("{OTHER_WINDOW_PREFIX}{}",app_handle.webview_windows().len()),
             "Moss Studio",
             (DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT),
+            app_handle
         )
         .expect("Failed to create new window"),
 

--- a/view/desktop/bin/src/window.rs
+++ b/view/desktop/bin/src/window.rs
@@ -64,15 +64,15 @@ pub fn create_window(app_handle: &AppHandle, input: CreateWindowInput) -> Webvie
 
     webview_window
 }
-
+// Maybe we should access the parent_window through manager by label
 pub fn create_child_window(
-    parent_window: WebviewWindow,
+    parent_label: &str,
     url: &str,
     label: &str,
     title: &str,
     inner_size: (f64, f64),
+    app_handle: AppHandle
 ) -> Result<(), String> {
-    let app_handle = parent_window.app_handle();
     let config = CreateWindowInput {
         url,
         label,
@@ -83,31 +83,23 @@ pub fn create_child_window(
             100.0 + random::<f64>() * 20.0,
         ),
     };
-
     let child_window = create_window(&app_handle, config);
 
-    {
-        let parent_window = parent_window.clone();
-        let child_window = child_window.clone();
-        child_window.clone().on_window_event(move |e| match e {
-            // When the new window is destroyed, bring the other up behind it
+    if let Some(parent_window) = app_handle.get_webview_window(parent_label){
+        child_window.on_window_event(move |e| match e {
+            // When the child window is destroyed, bring up the parent window
             WindowEvent::Destroyed => {
-                if let Some(w) = parent_window.get_webview_window(child_window.label()) {
-                    w.set_focus().unwrap();
-                }
-            }
+                parent_window.set_focus().unwrap();
+            },
             _ => {}
         });
     }
-
-    {
-        let parent_window = parent_window.clone();
-        let child_window = child_window.clone();
-        parent_window.clone().on_window_event(move |e| match e {
+    if let Some(parent_window) = app_handle.get_webview_window(parent_label) {
+        parent_window.on_window_event(move |e| match e {
             // When the parent window is focused, bring the child above
             WindowEvent::Focused(focus) => {
                 if *focus {
-                    if let Some(w) = parent_window.get_webview_window(child_window.label()) {
+                    if let Some(w) = app_handle.get_webview_window(child_window.label()) {
                         w.set_focus().unwrap();
                     };
                 }


### PR DESCRIPTION
1. According to documentation https://docs.rs/tauri/2.1.1/tauri/webview/struct.WebviewWindowBuilder.html, calling WebviewWindowBuilder from a synchronous command leads to a deadlock. Thus the command has been changed to async.
2. Instead of passing a copy of a window, it seems more appropriate to access the window through the `get_webview_window(label)` method on any instance that has the `Manager` trait, and app_handle seems like the best option.