### PR TITLE
feat(MOSSMVP-229): Implement CLI entry point with `info` command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1068,7 +1068,6 @@ dependencies = [
  "flume",
  "futures",
  "hashbrown 0.15.0",
- "hex_color",
  "homedir",
  "log",
  "macos-trampoline",
@@ -1090,6 +1089,7 @@ dependencies = [
  "strum",
  "tauri",
  "tauri-build",
+ "tauri-plugin-cli",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-fs",
  "tauri-plugin-log",
@@ -1915,15 +1915,6 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "hex_color"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d37f101bf4c633f7ca2e4b5e136050314503dd198e78e325ea602c327c484ef0"
-dependencies = [
- "rand 0.8.5",
-]
 
 [[package]]
 name = "homedir"
@@ -3788,9 +3779,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -4612,6 +4603,21 @@ dependencies = [
  "tauri-utils",
  "toml 0.8.19",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-cli"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bccd4692b56822a60874542c7655546c8e7aed3c2e2926166e1498e595bd2a2"
+dependencies = [
+ "clap",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror",
 ]
 
 [[package]]

--- a/view/desktop/bin/Cargo.toml
+++ b/view/desktop/bin/Cargo.toml
@@ -60,6 +60,7 @@ tauri-plugin-log = { version = "2.0.1", features = ["colored"] }
 tauri-plugin-window-state = "2.0.1"
 tauri-plugin-clipboard-manager = "2.0.1"
 tauri-plugin-fs = "2.0.0-rc.0"
+tauri-plugin-cli = "2.0.1"
 
 
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]

--- a/view/desktop/bin/src/cli.rs
+++ b/view/desktop/bin/src/cli.rs
@@ -1,0 +1,64 @@
+mod cli_info;
+
+
+use std::process::Command;
+use tauri::{AppHandle, Manager};
+use tauri_plugin_shell::ShellExt;
+use tauri_plugin_cli::{SubcommandMatches};
+use crate::AppState;
+use crate::cli::cli_info::info_handler;
+
+
+pub trait ShellClient {
+    async fn exec(&self, command: &str, args: Vec<&str>) -> Option<String>;
+}
+
+pub struct SystemShellClient;
+impl ShellClient for SystemShellClient {
+    async fn exec(&self, command: &str, args: Vec<&str>) -> Option<String> {
+        let output = Command::new(command)
+            .args(args)
+            .output();
+        match output {
+            Ok(output) => {
+                Some(String::from_utf8_lossy(output.stdout.as_slice()).to_string())
+            },
+            Err(error) => {
+                None
+            }
+        }
+    }
+}
+pub struct TauriShellClient<'a> {
+    pub(crate) app_handle: &'a AppHandle
+}
+
+impl ShellClient for TauriShellClient<'_> {
+    async fn exec(&self, command: &str, args: Vec<&str>) -> Option<String> {
+        let shell = self.app_handle.shell();
+        let output = shell
+            .command(command)
+            .args(args)
+            .output()
+            .await;
+        match output {
+            Ok(output) => {
+                Some(String::from_utf8_lossy(output.stdout.as_slice()).to_string())
+            },
+            Err(error) => {
+                None
+            }
+        }
+    }
+}
+
+
+pub async fn cli_handler(subcommand: Box<SubcommandMatches>, app_handle: AppHandle){
+    let app_state = app_handle.state::<AppState>();
+
+    match subcommand.name.as_str() {
+        "info" => info_handler(&*app_state, &app_handle).await,
+        _ => println!("Unknown subcommand")
+    }
+}
+

--- a/view/desktop/bin/src/cli/cli_info.rs
+++ b/view/desktop/bin/src/cli/cli_info.rs
@@ -1,0 +1,89 @@
+use tauri::{webview_version, AppHandle};
+use crate::AppState;
+use crate::cli::{ShellClient, SystemShellClient, TauriShellClient};
+
+pub async fn info_handler(app_state: &AppState, app_handle: &AppHandle){
+    let shell_client = TauriShellClient {app_handle};
+    println!("Environment");
+    println!("\t- OS: {}", get_os_info(app_state).await);
+    println!("\t- Webview: {}", get_webview_version().await);
+    println!("\t- rustc: {}", get_rustc_version(&shell_client).await);
+    println!("\t- cargo: {}", get_cargo_version(&shell_client).await);
+    println!("\t- rustup: {}", get_rustup_version(&shell_client).await);
+    println!("\t- Rust Toolchain: {}", get_rust_toolchain(&shell_client).await);
+    println!("\t- node: {}", get_node_version(&shell_client).await);
+    // FIXME: For some reason, it could not detect pnpm on my computer
+    println!("\t- pnpm: {}", get_pnpm_version(&shell_client).await);
+
+    println!("Packages");
+    println!("\t- tauri [Rust]: {}", get_tauri_version().await);
+
+    println!("App");
+    println!("\t- Moss: {}", get_moss_version(app_handle).await);
+
+}
+async fn component_version(shell_client: &impl ShellClient, component: &str, arg: &str) -> String {
+    let shell_output = shell_client.exec(
+        component,
+        vec![arg]
+    ).await;
+
+    match shell_output {
+        Some(output) => {
+            output.split('\n').next().unwrap_or("Not Found").to_string()
+        }
+        None => "Not Found".to_string()
+    }
+}
+
+async fn get_os_info(app_state: &AppState) -> String {
+    format!("{} {}", app_state.platform_info.os, app_state.platform_info.version)
+}
+
+async fn get_webview_version() -> String {
+    format!("{}", webview_version().unwrap_or("Not Found".to_string()))
+}
+
+async fn get_rustc_version(shell_client: &impl ShellClient) -> String {
+    component_version(shell_client, "rustc", "-V").await
+}
+
+async fn get_cargo_version(shell_client: &impl ShellClient) -> String {
+    component_version(shell_client, "cargo", "-V").await
+}
+
+async fn get_rustup_version(shell_client: &impl ShellClient) -> String {
+    component_version(shell_client, "rustup", "-V").await
+}
+
+async fn get_rust_toolchain(shell_client: &impl ShellClient) -> String {
+    let shell_output = shell_client.exec(
+        "rustup",
+        vec!["show", "active-toolchain"]
+    ).await;
+
+    match shell_output {
+        Some(output) => {
+            output.split('\n').next().unwrap_or("Not Found").to_string()
+        }
+        None => "Not Found".to_string()
+    }
+}
+
+async fn get_node_version(shell_client: &impl ShellClient) -> String {
+    component_version(shell_client, "node", "-v").await
+}
+
+async fn get_pnpm_version(shell_client: &impl ShellClient) -> String {
+    component_version(shell_client, "pnpm", "-v").await
+}
+
+async fn get_tauri_version() -> String {
+    tauri::VERSION.to_string()
+}
+
+async fn get_moss_version(app_handle: &AppHandle) -> String {
+    app_handle.config().clone().version.unwrap()
+}
+
+

--- a/view/desktop/bin/src/lib.rs
+++ b/view/desktop/bin/src/lib.rs
@@ -6,27 +6,26 @@ mod utl;
 mod window;
 
 pub mod constants;
+mod cli;
 
 use platform_core::context_v2::ContextCell;
 use platform_core::platform::cross::client::CrossPlatformClient;
 use platform_workspace::WorkspaceId;
 use rand::random;
 use std::env;
-use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::Arc;
-use homedir::{my_home};
-use tauri::{AppHandle, Manager, RunEvent, WebviewUrl, WebviewWindow, WindowEvent};
+use tauri::{AppHandle, Manager, RunEvent, WebviewWindow, WindowEvent};
+use tauri_plugin_cli::CliExt;
 use tauri_plugin_log::{fern::colors::ColoredLevelConfig, Target, TargetKind};
 use window::{create_window, CreateWindowInput};
 use workbench_desktop::window::{NativePlatformInfo, NativeWindowConfiguration};
 use workbench_desktop::Workbench;
-
-
+use crate::cli::cli_handler;
 use crate::commands::*;
 use crate::constants::*;
-use crate::plugins as moss_plugins;
 use crate::utl::get_home_dir;
+use crate::plugins as moss_plugins;
 
 #[macro_use]
 extern crate serde;
@@ -39,6 +38,7 @@ pub struct AppState {
 pub fn run() {
     #[allow(unused_mut)]
     let mut builder = tauri::Builder::default()
+        .plugin(tauri_plugin_cli::init())
         .plugin(
             tauri_plugin_log::Builder::default()
                 .targets([
@@ -138,8 +138,22 @@ pub fn run() {
         .expect("failed to run")
         .run(|app_handle, event| match event {
             RunEvent::Ready => {
-                let _ = create_main_window(app_handle, "/");
-            }
+                // Setting up CLI
+                match app_handle.cli().matches() {
+                    Ok(matches) => {
+                        let subcommand = matches.subcommand;
+                        if subcommand.is_none(){
+                            let _ = create_main_window(app_handle, "/");
+                        } else {
+                            tauri::async_runtime::spawn(
+                                cli_handler(subcommand.unwrap(), app_handle.clone())
+                            );
+                        }
+                    },
+                    Err(_) => {}
+                };
+
+            },
 
             #[cfg(target_os = "macos")]
             RunEvent::ExitRequested { api, .. } => {

--- a/view/desktop/bin/tauri.conf.json
+++ b/view/desktop/bin/tauri.conf.json
@@ -30,5 +30,18 @@
     "windows": {
       "digestAlgorithm": "sha256"
     }
+  },
+
+  "plugins": {
+    "cli": {
+      "description": "Moss CLI",
+      "args": [],
+      "subcommands": {
+        "info": {
+          "description": "Provide information about the Moss application, including environment and packages",
+          "args": []
+        }
+      }
+    }
   }
 }


### PR DESCRIPTION
1. When starting up, the app will check if a CLI subcommand is provided: if so, the app will call a `cli_handler` and bypass window creation.
2. Implement first CLI subcommand `info` which displays basic information about the app and the running environment. 
3. Implement `ShellClient` trait with two implementations `SystemShellClient` and `TauriShellClient`, which would be used by the info_handler to query components info. This enables future mockup.
4. Organize specific CLI handler code into a separate cli folder, with `cli.rs` only keeping a dispatcher.