### PR TITLE
DevOps(MOSSMVP-263): Set up pre-commit `rustfmt` hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+rustup component add rustfmt
 pnpm exec lint-staged

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "precommit": "lint-staged"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx,css,md,json}": "prettier --plugin=prettier-plugin-tailwindcss --write"
+    "*.{js,jsx,ts,tsx,css,md,json}": "prettier --plugin=prettier-plugin-tailwindcss --write",
+    "*.rs": "rustfmt"
   },
   "devDependencies": {
     "@ianvs/prettier-plugin-sort-imports": "^4.3.1",


### PR DESCRIPTION
Change the configuration of `lint-staged` so that any staged rust file will be formatted using `rustfmt` before commit.