### PR TITLE
chore(MOSSMVP-237): Set up Github Action for `git-cliff`

### DIFF
--- a/.github/workflows/git-cliff.yml
+++ b/.github/workflows/git-cliff.yml
@@ -1,0 +1,24 @@
+on:
+  pull_request
+
+jobs:
+  changelog:
+    name: Generate changelog
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Generate a changelog
+        uses: orhun/git-cliff-action@v4
+        id: git-cliff
+        with:
+          config: cliff.toml
+          args: v0.0.0.. --verbose
+        env:
+          OUTPUT: CHANGELOG.md
+
+      - name: Print the changelog
+        run: cat "${{ steps.git-cliff.outputs.changelog }}"


### PR DESCRIPTION
This PR sets up a github action that automatically generates a changelog for each pull request, as explained in PR #135 