### PR TITLE
fix: Make `git-cliff` action automatically generate a CHANGELOG.md

### DIFF
--- a/.github/workflows/git-cliff.yml
+++ b/.github/workflows/git-cliff.yml
@@ -5,6 +5,8 @@ jobs:
   changelog:
     name: Generate changelog
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -16,9 +18,20 @@ jobs:
         id: git-cliff
         with:
           config: cliff.toml
-          args: v0.0.0.. --verbose
+          args: --verbose
         env:
           OUTPUT: CHANGELOG.md
+          GITHUB_REPO: ${{ github.repository }}
 
       - name: Print the changelog
         run: cat "${{ steps.git-cliff.outputs.changelog }}"
+
+      - name: Push the changelog
+        run: |
+          git checkout ${{ github.head_ref }}
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add CHANGELOG.md
+          git commit -m "Update changelog"
+          git push https://${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git ${{ github.head_ref }}
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,732 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [unreleased]
+
+### 🚀 Features
+
+- Added a template for creating an abstract client (@seniorkonung)
+- Implemented recursive retrieval of overrides
+- In the process of developing a registry of schemes
+- First implementation of a configuration registry
+- Implemented the collection of all configuration parameters to form a settings scheme
+- Implementation of a mechanism for working with exceptions + docs
+- Refactoring
+- Started implementing the registry into the parser
+- *(create-turbo)* Apply official-starter transform
+- *(create-turbo)* Apply pnpm-eslint transform
+- *(create-turbo)* Install dependencies
+- *(create-turbo)* Apply official-starter transform
+- *(create-turbo)* Apply pnpm-eslint transform
+- *(create-turbo)* Install dependencies
+- *(create-turbo)* Apply official-starter transform
+- *(create-turbo)* Apply pnpm-eslint transform
+- *(create-turbo)* Install dependencies
+- Finalizing the configuration scheme registration logic
+- Added secondary fields which
+- Added simple statusbar
+- Updated ESLint configuration to enforce React components as arrow functions only
+- Added olive colors to shared tailwind config
+- Initializing modules
+- Started implementing the basic mechanism for applying changes to settings
+- Queue draft
+- Updated tailwind and storybook configs
+- Added categories and folders to storybook stories
+- Added StatusBar story
+- Added folder to page story
+- Added Example compoent in web directory
+- Added Example component to docs
+- Implemented a job queue
+- Added docusaurus to docs folder
+- Added example docs to view folder
+- Implemented the concept of configuration policies
+- Implemented the functionality of using certain policies when reading data
+- Implemented a key inspection mechanism
+- Implemented the functionality of updating data in the file and the system
+- *(MOSSMVP-85)* Backend initial configuration policy ([#62](<REPO>/issues/62))
+- *(configuration)* Implementation of the structure and macro of the key
+- Add fonts.css to build process and exports
+- Added Inter font to shared tailwind config
+- Imported Inter font to desktop app
+- Implemented an updated mechanism for working with keys for update operations
+- Optimized work with attribute names in configuration models
+- *(MOSSMVP-119)* Implement a more advanced approach to working with keys ([#64](<REPO>/issues/64))
+- Tooltip component in progress
+- Added storybook script alias
+- Added Tooltip
+- Removed unused files
+- Added Tooltip export
+- Added tooltip example
+- Set Tooltip with arrow as a default
+- Added asChil property to Tooltip
+- Added Story to Tooltip and changed default Tooltip text
+- (MOSSMVP-111) Frontend Create Tooltip component  ([#67](<REPO>/issues/67))
+- (MOSSMVP-116) Frontend App header ([#65](<REPO>/issues/65))
+- Added Dropdown menu
+- Added Dropdown menu dependency
+- Added storybook addon for viewing figma components inside of storybook
+- Added storybook addon dependency
+- Configured Dropdown menu types
+- Added Dropdown menu story
+- Added Dropdown menu export from shared folder
+- Changed styles for icons
+- Added TODO
+- *(MOSSMVP-117)* Frontend Implement Dropdown Menu ([#69](<REPO>/issues/69))
+- Svgr example
+- Updated svgr config
+- Added new icon component to Home page
+- Added some svg icons
+- Change icon color example
+- Applied new icon component to Desktop App page
+- Changed Icon component
+- Added icon stories
+- Initialized the work environment configuration module
+- WorkspaceService
+- Workspace implementation
+- Advanced implementation of service collection
+- Made a small API pass to the frontend
+- Implemented integration of the workspace services with the work area
+- *(MOSSMVP-105)* Workspace configuration service ([#66](<REPO>/issues/66))
+- Updated DropdownMenu icon functionallity
+- Added simple README to icons
+- Added icon stories
+- Added removal of builded icons before new builds
+- *(MOSSMVP 141)* Frontend Review the icon integration mechanism ([#71](<REPO>/issues/71))
+- Added Lato font
+- Added font family for shortcut
+- *(MOSSMVP 134)* Frontend Change Desktop Application Font ([#73](<REPO>/issues/73))
+- (MOSSMVP 138): Frontend Test implemented windows controls buttons on Linux ([#72](<REPO>/issues/72))
+- *(MOSSMVP-128)* Organize the application layout  ([#74](<REPO>/issues/74))
+- Added command to start surrealDB from root
+- Added Badge component
+- Added All Variants story to Icon stories
+- *(MOSSMVP 136)* Frontend Badge component ([#75](<REPO>/issues/75))
+- First drafts of real configurations
+- Attempt to implement optimizations
+- Using first configurations
+- Implemented the application of window size configuration settings
+- Implemented the environment module
+- *(MOSSMVP-142)* Expanding and stabilizing workspace modules ([#70](<REPO>/issues/70))
+- Initialized theme generation service
+- Implemented FileService into UserService
+- Implemented FileService into UserConfiguration
+- *(MOSSMVP-118)* Platform file service ([#77](<REPO>/issues/77))
+- Implemented dynamic tailwind themes
+- Implemented dynamic themes to linux window controls
+- Implemented dynamic themes to windows window controls
+- Implemented ThemeSelector and LanguageSelector
+- Added more translations
+- (MOSSMVP-113) Implement dynamic themes with React & TailwindCSS ([#79](<REPO>/issues/79))
+- Implemented saving languages ​​to local storage
+- Implemented theme switcher to Storybook
+- (MOSSMVP-159) Implement tailwind themes to Storybook ([#80](<REPO>/issues/80))
+- Initial setup of theme generator
+- Start of integration of the event system
+- Async context
+- First stabilization of context functionality
+- AsyncContext
+- Moved secondary commands to makefile
+- Added base of Resizable component
+- Added stories to Resizable component
+- Added new Resizable library
+- *(MOSSMVP-146)* Frontend Implementation of a functional sidebar  ([#81](<REPO>/issues/81))
+- *(MOSSMVP-157)* Frontend Transfer all secondary commands to Makefile ([#82](<REPO>/issues/82))
+- Added command to get native platform information
+- Added the ability to start and stop the database in the background
+- *(MOSSMVP-151)* Backend exchange of events through the pub sub mechanism ([#84](<REPO>/issues/84))
+- Added sdk-ts and tools directories to root
+- Implemented @repo/theme sdk-ts and added to theme provider
+- Added validation of theme HEX colors
+- Implemented fetching of themes at desktop app
+- Replaced default color format from HEX to RGBA in sdk-ts theme
+- Implemented theme generator
+- Implemented new theme providing logic to storybook
+- Added stories demostrating how to use overflow inside Resizable component
+- Added text ellipsis and content overflow for Resizable component on desktop main page
+- Added overflow scroll on X axis on sidebar component
+- Added conditionas border radius to header
+- *(MOSSMVP-156)* Frontend Content adaptation mechanism ([#83](<REPO>/issues/83))
+- Tracing-subscriber integration into the platform
+- Added temporary Logs page to the desktop app
+- Logging init & send them to frontend
+- Cleanup. Added some comments
+- Tracing-subscriber integration into the platform
+- Added temporary Logs page to the desktop app
+- Logging init & send them to frontend
+- Cleanup. Added some comments
+- *(MOSSMVP-152, MOSSMVP-153)* Backend logging library integration and forwarding to the frontend ([#88](<REPO>/issues/88))
+- *(MOSSMVP-158)* Implement theme generation  ([#87](<REPO>/issues/87))
+- Env macros
+- Core configurations
+- NativePlatformInfo
+- Context 2.0
+- Woth context
+- Working version
+- Implementation of license symlink generation
+- Implemented rust workspace audit (rwa) xtask
+- Provider
+- Implemented the ability for users to specify a config file using the --config-file flag when running the rwa subcommand
+- *(MOSSMVP-182)* Replaced Tailwind custom variables with CSS variables in classNames ([#95](<REPO>/issues/95))
+- *(MOSSMVP-178)* Atoms and selectors ([#93](<REPO>/issues/93))
+- Added redux
+- Integrated language selector into redux
+- Added react-devtools
+- Moved theme logic to Redux
+- *(MOSSMVP-172)* Frontend Redux integration  ([#96](<REPO>/issues/96))
+- Integrated event subscription mechanism
+- *(MOSSMVP-191)* Install Prettier plugin for Tailwind CSS ([#98](<REPO>/issues/98))
+- *(MOSSMVP-181)* Auto-generation of mapping functions for generating themes ([#97](<REPO>/issues/97))
+- Implementation of generic functions for working with nodes in all contexts
+- Moved storage of selector computers to global storage
+- A generic immutable map type for storing any type of node
+- *(MOSSMVP-190)* Backend subscriptions observers and effects ([#99](<REPO>/issues/99))
+- `crater` library integration
+- First UI implementation using ESC lib
+- Added `loc` command
+- Internal moss UI libs
+- Small util for generating bindigs from Rust to TS
+- Gen-bindings
+- Moved the export of bingings to a separate crate
+- Added basic draggable accordion
+- Added new icon
+- Added sidebar header
+- Added styling, registered components and made accrodion movable
+- Added handle to draggable accordion
+- Very basic implementation of dnd-kit
+- Very basic implementation of React beautiful DND
+- Added implementation of Beautiful DND with resizeable accordion
+- Uncomplete implementation of react-resizable-panels
+- Sidebar implementation with allotment
+- *(MOSSMVP-186)* Frontend Implement a common sidebar ([#100](<REPO>/issues/100))
+- *(MOSSMVP-198)* Backend implementation of the composition mechanism ([#105](<REPO>/issues/105))
+- Group
+- Disabled the use of the database
+- New impl of the implementation of parts and contributions
+- Side bar part draft impl
+- Implemented the functionality to bind a View model to a view descriptor
+- Passed data retrieval to the frontend
+- *(MOSSMVP-215)* Backend implementation of frontend architecture description ([#108](<REPO>/issues/108))
+- Moved uikit library
+- Implemented and configured shared models
+- Added models generation command
+- TS types import mechanism
+- Implemented workbench-level models
+- *(MOSSMVP-216)* Backend type script bindings from rust ([#109](<REPO>/issues/109))
+- Implemented the first context menus
+- Simple language interface generation
+- Simple implementation of backend lang
+- *(MOSSMVP-126)* Frontent UI localization ([#111](<REPO>/issues/111))
+- Added LinkArrow.svg
+- Added Link component and reworked Tooltip
+- Added Context Menu
+- Added simple icon gallery
+- *(MOSSMVP-202)* Frontend UI cleanup  ([#110](<REPO>/issues/110))
+- Added implementation of toggled context menu item
+- Implementation of optimized identifiers for builtin tokens
+- *(MOSSMVP-218)* Menu registry ([#114](<REPO>/issues/114))
+- First version of event bus
+- Initial version of the service architecture
+- Integrated a plugin responsible for positioning window control buttons on a macOS
+- Implemented launch via tokio runtime
+- Implemented HTML link models
+- `Links` view content
+- Moved definition of HTML models to UI Kit
+- *(MOSSMVP-224)* Preparing primary side bar contributions to provide them on the frontend ([#115](<REPO>/issues/115))
+- Added shell.nix
+- Added versions to flake.nix
+- Updated flake.nix so that the desired versions would be used. Upd README.md
+- Added separate nixpkgs to handle the required surrealdb version
+- Additional libsin flake.nix for installation process
+- Added some env variables to flake.nix
+- Attempt to make nix working by using example
+- Fixed error with glib and openssl version. Attempting to fix BAD_DISPLAY error
+- Pre-merge changes
+- Implemented the multi-window
+- *(MOSSMVP-232)* Window state integration ([#117](<REPO>/issues/117))
+- Implemented content localization
+- *(MOSSMVP-127)* Localization of returned content ([#118](<REPO>/issues/118))
+- Added HeadBar without DnD
+- Added conditional rounded borders fo different OS
+- Added DnDKit to HeadBar
+- Enabled zoom hotkeys in tauri
+- Added overflow to HeadBar
+- HeadBar wrappable menu
+- (MOSSMVP-220): HeadBar implementation ([#123](<REPO>/issues/123))
+- *(MOSSMVP-229)* Fix the workspace dependencies ([#129](<REPO>/issues/129))
+- Added IBMPlexMono font
+- *(MOSSMVP-176)* Frontend New fonts ([#130](<REPO>/issues/130))
+- *(MOSSMVP-229)* Implement CLI entry point with `info` command
+- *(MOSSMVP-229)* Implement CLI entry point with `info` command ([#128](<REPO>/issues/128))
+- Added new dropdown menu using menu primitives
+- Added auto-generation of actions models
+- *(MOSSMVP-221)* Preparing head bar contributions to provide them on the frontend ([#126](<REPO>/issues/126))
+- *(MOSSMVP-238)* Frontend Finalizing UI Headbar  ([#133](<REPO>/issues/133))
+- Backend support for different color formats in themes
+- *(MOSSMVP-247)* Forwarding the theme to the frontend ([#138](<REPO>/issues/138))
+
+### 🐛 Bug Fixes
+
+- Cargo.toml
+- Platform-specific code isolation
+- Tauri deps
+- Made the ID field required
+- *(configuration)* Moved the configuration module to the platform level
+- Problem with data loss when merging models
+- Removed docusaurus auto generated files
+- Fixed fonts import for storybook
+- Fixed fonts import for storybook
+- Fixed gap between arrow and tooltip
+- Tooltip name in storybook
+- Trigger tooltip only if trigger is button
+- *(https://github.com/4rchr4y/moss/commit/38e61a84d46b532c9ec266ee89850d5c873bf59c)* Pnpm version
+- Https://github.com/4rchr4y/moss/commit/01e83076fa25f904ff51059605fabfaea45e5c21
+- DropdownMenu stories type error
+- The problem with configuration fields being lost
+- Missing import
+- Fixed stroybook cannot see aliases
+- Cannot find window context
+- Fixed stroybook cannot see aliases
+- Fixed resizable functionality after merge
+- Fixed cn path
+- Bug with stretching application content
+- Adapt makefile for windows
+- Title bar isnt draggable when being on left side
+- Conditional border radius not working
+- Fixed introduced bug from merging from master
+- Pull from main branch, merging error fixes
+- Themes fix  ([#90](<REPO>/issues/90))
+- *(MOSSMVP-152, MOSSMVP-153)* Advance merge with MOSSMVP-164 ([#91](<REPO>/issues/91))
+- Async logic
+- Rwa
+- Conditionally load react-devtools script for development mode
+- Bug with an unupdated context when subscribing to a node
+- Ignoring svgr when generating icons ([#101](<REPO>/issues/101))
+- Removed invalid typescript path
+- Accordion trigger activation
+- TS error wen calling setLanguageFromLocalStorage
+- CompilerOptions->jsx field
+- Removed  gen-bindings
+- Build problem on windows
+- Rerended whole app when theme changes
+- Reduced color change delay(but i didn't remove it completely )
+- Storybook temporary fix
+- Hiding all windows and preventing exit
+- Bug fixed by dragging window
+- Window control bug
+- Fix corners and transparency of tauri app
+- Fix corners and transparency on linux
+- Fix corners and transparency on linux
+- Not rounded window
+- Window fullscreen toggle
+- First element of DND  overflow list is always overflown on linux
+- Treat the absence of user config file as an empty config
+- Update readme and change logic for checking home directory & user config file ([#120](<REPO>/issues/120))
+- Gen-icons command
+- *(MOSSMVP-234)* Fix deadlock on clicking New Window button ([#127](<REPO>/issues/127))
+- DropdownMenu trigger couldn't be dragged
+- Draggable ActionGroup could be swapped with invisible items
+- Label words breaking in ActionsGroup on Windows
+- Draggable ActionGroup could be swapped with invisible items on Windows
+- Added full path when using LocalizedString type
+- Gen-icons command
+- Missing imports
+- Make `git-cliff` action automatically generate a CHANGELOG.md
+
+### ◀️ Revert
+
+- Recovered an accidentally deleted file
+- Names
+- Fix: conditionally load react-devtools script for development mode
+- Accidentally deleted TS SDK folder
+
+### 📚 Documentation
+
+- Added api reference to tooltip
+- Added icons README to view/shared/ui
+- Changed stroke Icon story
+- Update README.md
+- Added Contents on top
+- Updated README.md
+- Added Community and Overview pages to docasaurus. Cleanup in header/footet navigation
+- Renamed Community index.md to Overview, removed example page
+- Fix typo in Overview
+- Update docusaurus.config.ts, added NOTE about commented-out code
+- *(MOSSMVP135)* README.md rewrite. Changes to documentation website structure (header, footer navigation) ([#78](<REPO>/issues/78))
+- Updated README
+- Updated README
+- Updated description
+- Fix typo
+- *(MOSSMVP-211)* Preparing the base and structure of pages ([#106](<REPO>/issues/106))
+- Added documentation for quote macro
+
+### ⚡ Performance
+
+- Got rid of locks and fixed a bug with the loss of overwritten configurations
+- Reduced the number of clonings
+
+### 🎨 Styling
+
+- Formatting with new settings
+- Added spell words
+- Changed Tooltip background color
+- Changed Tooltip background color back to black and removed unnecessary styles
+- Changed Dropdown menu border radiuses
+- Changed dropdown styles
+- Changed Dropdown icon padding
+- Changed back Dropdown icon padding
+- Changed icon hover styles
+- Changed font of dropdown shortcut to Lato
+- Aligned windows control buttons vertically
+- Added styling on handle hover and drag
+- Changed layout padding in dropdown menu stories
+- Icons all variant center
+- Added horizontal handle styles
+- Removed font shortcut from tailwind config
+- Changed story attributes
+- Updated styles
+- Restyled Draggable Accordeon
+- Sort tailwind classes
+- Hide border on dragging
+- Accordion dragging
+- Moved cursor-pointer to the accordion trigger
+- Changed tailwind font sizes
+- Changed default font family to Inter
+- Changed base tailwind font size back to 16px, but leave base font size 13px for text only
+- Changed Context menu styles
+- Checkbox font regular
+- Tooltip
+- Context menu gap between shortcuts
+- Added shadow for submenu
+- Removed cursor-pointer
+- Added zIndex while HeadBarButton dragging
+- Changed icon size
+- Hover change
+- Bg change
+- Changed HeadBar dragging widget styles
+- Changed HeadBar dragging widget styles
+- Changed HeadBar dragging widget styles
+- Changed HeadBar rounded
+- Changed hover style
+- Changed HeadBar dragging widget styles
+- Changed backgrounds
+- Rouneded
+- Changed HeadBar hover style
+- Px WidgetBar change
+- Px WidgetBar change
+- Widget button padding
+- Gaps
+- Wrappable menu items
+- Overflown menu on linux
+- Overflown menu on windown
+- ActionsGroup paddings
+- ActionsGroup paddings
+- ActionsGroup paddings
+- ActionsGroup paddings
+- ActionsGroup icon style change
+- ActionsGroup styles
+- ActionsGroup styles
+- ActionsGroup styles
+- ActionsGroup styles
+- ActionsGroup styles
+
+### 🚜 Refactor
+
+- Logic review and refactoring
+- Logic review. Part 1
+- Refactor StatusBar according to new ESLint rule
+- Removed wrapper divs from buttons and useless style imports
+- Separation of user interface and comon functionality into folders
+- CompositeKey
+- Update settings value
+- Integration of a new type of key into existing modules
+- Move fonts folder to static directory
+- Implementation with the introduction of a prefix tree
+- Improved the code for getting values
+- Changed Tooltip template in storybook
+- Added more text to tooltip story
+- Removed unnecessary styles
+- Sorting Dropdown menu primitives
+- Updatred Icon components in Dropdown Menu strories
+- Renamed Acc svg
+- Icon stories
+- Modules and setting up the application's working environment
+- Renaming modules to follow convention
+- Renaming files
+- Removed icon group state
+- *(configuration_registry)* Improved API
+- Moss_base -> moss_std
+- Service_group -> service_registry
+- *(configuration)* Structuring and separating modules
+- Created THEMES const
+- Added fixme to remove all hardcoded values from  constants
+- Migrated to platform core
+- Restructuring and simplifying access to entities
+- Min size
+- Changed resizable story
+- Added default command and improved structuring
+- Restructuring and refactoring of commands
+- Moved theme reading from files from applyTheme to theme provider
+- Refactored theme implementation to desktop
+- Refactoring of ThemeProvider and corresponding components and functions
+- Renamed tailwind custom colors
+- Renamed theme typs in theme sdk-ts
+- Renamed some Theme color variables
+- Refactoring of storybook preview
+- Uncommented icon
+- Moved TitleBar and StatusBar to layout
+- Moved session information to separate component
+- Refactored App
+- Refactoring of theme sdk-ts
+- Add logging + symlinks replaced witt relative path
+- Refactoring
+- Refactoring
+- Refactoring
+- Refactoring of license
+- Moved loading of workspace and initialization of logger from tasks to main
+- Refactoring
+- Refactored license xtask
+- Refactoring
+- Refactoring
+- Renamed workspace to metadata
+- Finalization
+- Moved Sidebar to its own component
+- Moved pages to it's own directory
+- Refactoring redux slices
+- Split files into entity files and context files
+- Templatization and universalization of node leasing tools
+- Optimized the number of weak and proto entities
+- Got rid of storing extra type in weak structures
+- Computer struct visability
+- Blanket implementation for EventEmitter
+- Moved to the core library
+- Simplified the entry point
+- Removing obsolete crates
+- Moss_std -> platform_core::base
+- Removing obsolete crates and refactoring to latest requirements ([#104](<REPO>/issues/104))
+- Old and unused imports
+- Removing unnecessary files and imports
+- Extracted UI ECS lib
+- Improved structuring
+- Added warnings
+- Got rid of the trash
+- Merged two function into one
+- Accordions list
+- Imports
+- More flexible level implementation of part contributions
+- More in-depth architecture development of tree-like representation
+- Separated views  from containers
+- Switched to using the term TreeViewGroup instead of TreeViewContainer
+- Cleanup
+- Simplifying the structure of shared models
+- Moving backend code for the platform and workbench into the internal folder
+- Renamed module `workbench_tao` -> `workbench_desktop`
+- Moved context menu primitives up a folder
+- Minor edits and improvements
+- Made the registries thread-safe and started implementing the service layer
+- Fixed the cause of panic detection and improved optimization of identifiers
+- Optimized identifiers and string storage
+- Renaming built-in entities according to the established standard
+- Moved into `commands`
+- Global changes to the application entry point
+- Dead code removal
+- Base library transfer
+- Introduced the use of new string types
+- HeadBar
+- HeadBar
+- Moved old code to Controls folder
+- HeadBar
+- Removed tauri provider from controls
+- Changed back tauri windows provider
+- HeadBar
+- HeadBar
+- HeadBar DND oberflow list
+- Changed Context Menu to Dropdown in HeadBar
+- Use homedir crate to retrieve the home directory
+- *(MOSSMVP-236)* Remove unused dependencies and move crate dependencies to workspace ([#122](<REPO>/issues/122))
+- Changed item in headbar list
+- Removed HeadBarButton
+- Changed Overflown menu items
+- Removed excessive overcomplication from the code
+- Moved the model definitions to the models crate
+- Split the shared models crate into two independent crates and configured type export to TypeScript.
+- *(MOSSMVP-264)* Move the UIKit models to the crate folder ([#137](<REPO>/issues/137))
+- Change color format in theme files
+- Add `get_themes_dir` utility function
+- Move theme parsing logic to the backend
+- Make `fetch_all_themes` command list invalid theme files as well
+- Replace `moss-models` with `desktop-models`
+- *(MOSSMVP-267)* Remove all specta dependencies ([#139](<REPO>/issues/139))
+
+### 🧪 Testing
+
+- Rewrite tests for color parsing
+
+### 🏗️ Build
+
+- *(rust)* Bump hashbrown from 0.7.2 to 0.14.5
+- *(rust)* Bump hashbrown from 0.7.2 to 0.14.5 ([#61](<REPO>/issues/61))
+- *(rust)* Bump serde_with from 3.8.3 to 3.9.0
+- *(rust)* Bump serde_with from 3.8.3 to 3.9.0 ([#60](<REPO>/issues/60))
+- *(rust)* Bump lazy-regex from 3.1.0 to 3.2.0
+- *(rust)* Bump lazy-regex from 3.1.0 to 3.2.0 ([#57](<REPO>/issues/57))
+- *(rust)* Bump tokio from 1.38.0 to 1.39.2
+- *(rust)* Bump tokio from 1.38.0 to 1.39.2 ([#59](<REPO>/issues/59))
+- *(rust)* Bump async-executor from 1.12.0 to 1.13.0
+- *(rust)* Bump async-executor from 1.12.0 to 1.13.0 ([#58](<REPO>/issues/58))
+- Updated pnpm version
+- Removed separate fonts.css file from build
+- Updated pnpm-lock dependency
+- Removed pragmatic-drag-and-drop from project
+- Added dnd-kit to project
+- *(rust)* Bump lazy-regex from 3.2.0 to 3.3.0
+- *(rust)* Bump lazy-regex from 3.2.0 to 3.3.0 ([#85](<REPO>/issues/85))
+- *(rust)* Bump tokio from 1.39.2 to 1.40.0
+- *(rust)* Bump tokio from 1.39.2 to 1.40.0 ([#86](<REPO>/issues/86))
+- Pnpm-lock update
+- *(rust)* Bump hashbrown from 0.14.5 to 0.15.0
+- *(rust)* Bump hashbrown from 0.14.5 to 0.15.0 ([#113](<REPO>/issues/113))
+- *(rust)* Bump tokio from 1.40.0 to 1.41.0
+- *(rust)* Bump tokio from 1.40.0 to 1.41.0 ([#112](<REPO>/issues/112))
+- Pnpm-lock update
+- Update pnpm-lock.yaml
+
+### ⚙️ Miscellaneous Tasks
+
+- Clean up old mgration files
+- Moved StatusBar to desktop
+- Deleted StatusBar from shared
+- Add temporary prop to StatusBar for demonstration purposes
+- Cleaned up imports
+- Added word to workspace settings
+- Changed icon color back to stone
+- Update turbo.json to include build/** in outputs
+- Update docusaurus scripts in package.json
+- Changed github pages deployment path
+- Remove obsolete settings
+- *(MOSSMVP-101)* Prepare the publication of the documentation site on GitHub pages ([#52](<REPO>/issues/52))
+- Settings migration
+- Final setup
+- *(deps)* Bump actions/download-artifact from 3 to 4
+- *(deps)* Bump actions/upload-artifact from 3 to 4
+- Update static.yml
+- Cleanup
+- Extend docusaurus tsconfig.json with base configuration
+- Set a timeout for jobs
+- Removed docusaurus auto generated files
+- Removed unused styles
+- Turi version bump
+- Clean up
+- Refactoring
+- Chnaged command to start docs from root
+- Removed electron desktop app + refactoring
+- Reconfiguration
+- Update pnpm-lock.yaml
+- Removed depricated icons
+- Removed depricated icon
+- Removed unused components
+- Removed depricated component
+- Refactoring
+- Removed .ttf files
+- Refactoring
+- Refactoring
+- Implemented reading of themes from files
+- Added `cleanup` command
+- Cleaning outdated libraries
+- *(platform)* Simplification of the folder structure for platform modules
+- Moved tailwind theme provider from desktop to shared
+- Remove jsonnet implementation
+- Styles indentation
+- Renamed component Resizable to ResizablePanel
+- Removed annoying console log
+- Removed assets dorectory from view\shared\ui\src\assets
+- Removed obsolete directory
+- Removed spaces
+- Removed unnecessary style
+- Component name shortened
+- Removed useless check
+- Merge branch 'MOSSMVP-152-Backend-Logging-library-integration' of github.com:4rchr4y/moss into MOSSMVP-152-Backend-Logging-library-integration
+- Removed Settings props, turned off i18n logging
+- Added FIXME
+- Initial cleaning of imports and unused code
+- Added command to generate icons
+- Minor changes caused by formatting and deleting old files
+- Added ignore header for eslint
+- Global renaming `tgui` -> `tao`
+- Added `**/*.rs.bk`
+- Renaming Moss Compass -> Moss Studio
+- `lib-rs/moss_uikit`
+- Cleanup
+- Cleanup
+- Removed unnecessary files and dependencies
+- Removed default hover from icon
+- Cleanup
+- Cleanup
+- Initialized the workbench models crate
+- Final autogeneration of models
+- Removed generating interfaces
+- Removed log
+- Removed unused files, added FIXME
+- Cleanup of imports and types
+- Tooltip fix bg and link's arrow lineup
+- Small chores
+- The improved and structured Makefile
+- Removed the settings that create the default window
+- Not a very useful warning
+- Removed the capabilities section
+- Added event relaterd permission
+- Old file
+- Removed unused styles
+- Small chores
+- Removed styles
+- Small chores
+- Removed console.log
+- Added types
+- Automatic changes
+- Removed old DropdownMenu component
+- HeadBar chore
+- HeadBar chores
+- HeadBar chores
+- *(MOSSMVP-237)* Set up Github Action for `git-cliff` ([#134](<REPO>/issues/134))
+- Setting up `git-cliff` for automatic changelog generation
+- *(MOSSMVP-237)* Setting up `git-cliff` for automatic changelog generation ([#135](<REPO>/issues/135))
+- Fixed an error in the README file
+
+### DevOps
+
+- *(MOSSMVP-263)* Set up pre-commit `rustfmt` hook ([#132](<REPO>/issues/132))
+
+### WIP
+
+- Draggable ActionsGroup
+
+### Chrone
+
+- *(lib)* Restructured `moss_std`
+- *(async_utl)* Restructured and removed this module
+- Added `workspace.resolver` = 2
+
+### Deps
+
+- Async-task + flume
+
+### Draft
+
+- Linker implementation
+- Views and components
+- Implementation of a view management system
+- Experiments with binding
+- Changed the utility for bindings and implemented custom export of bindings
+- Beginning of structuring side views
+- Implemented a more flexible way of describing parts
+- Raw menu implementation
+
+### Frat
+
+- Removed unsupported libs from flake.nix
+
+### Https
+
+- //graphql.org/learn/best-practices/#versioning
+
+<!-- generated by git-cliff -->


### PR DESCRIPTION
For every pull request now, `git-cliff` action will automatically generate a CHANGELOG.md and append it to the PR as a new commit. Since we don't have proper versioning system right now, the CHANGELOG.md is not very readable and useful, and I will probably need to further tweak the workflow in the future