### PR TITLE
feat(MOSSMVP-284): Implement a theme installation util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -742,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+checksum = "fb3b4b9e5a7c7514dfa52869339ee98b3156b0bfb4e8a77c4ff4babb64b1604f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -752,9 +752,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.20"
+version = "4.5.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+checksum = "b17a95aa67cc7b5ebd32aa5370189aa0d79069ef1c64ce893bd30fb24bff20ec"
 dependencies = [
  "anstream",
  "anstyle",
@@ -5205,6 +5205,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "themeinstall"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "moss_themeconv",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ members = [
     "internal/workbench/service/user_profile/tao",
     "internal/workbench/service/environment/tao",
 
-    "tools/xtask",
+    "tools/xtask", "misc/themeinstall",
 ]
 
 [profile.release]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ members = [
     "internal/workbench/service/user_profile/tao",
     "internal/workbench/service/environment/tao",
 
-    "tools/xtask", "misc/themeinstall",
+    "tools/xtask",
+    "misc/themeinstall",
 ]
 
 [profile.release]

--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,19 @@
 # Detect Operating System
 ifeq ($(OS),Windows_NT)
     DETECTED_OS := Windows
+    HOME_DIR := ${USERPROFILE}
 else
     DETECTED_OS := $(shell uname)
+    HOME_DIR := ${HOME}
 endif
 
-# Directories
+# App Directories
 DESKTOP_DIR := view/desktop
 STORYBOOK_DIR := view/storybook
 DOCS_DIR := view/docs
 WEB_DIR := view/web
 THEME_GENERATOR_DIR := tools/themegen
+THEME_INSTALLER_DIR := misc/themeinstall
 ICONS_DIR := tools/icongen
 
 DESKTOP_MODELS_DIR := internal/workbench/desktop/models
@@ -20,6 +23,10 @@ HTML_MODELS_DIR := crates/moss-html
 UIKIT_MODELS_DIR := crates/moss-uikit
 
 XTASK_DIR := tools/xtask
+
+# User Directories
+THEME_DIR := ${HOME_DIR}/.config/moss/themes
+
 # Executables
 PNPM := pnpm
 SURREAL := surreal
@@ -96,10 +103,19 @@ endif
 
 # Generation Commands
 
-## Generate Themes
+## Generate Theme JSONs
 .PHONY: gen-themes
 gen-themes:
 	@cd $(THEME_GENERATOR_DIR) && $(PNPM) start
+
+## Convert Theme JSONs to css
+.PHONY: install-themes
+install-themes:
+	$(CARGO) run --bin themeinstall -- --input ${THEME_DIR}\moss-dark.json --output $(THEME_DIR)
+	$(CARGO) run --bin themeinstall -- --input ${THEME_DIR}\moss-light.json --output $(THEME_DIR)
+	$(CARGO) run --bin themeinstall -- --input ${THEME_DIR}\moss-pink.json --output $(THEME_DIR)
+
+
 
 ## Generate Icons
 .PHONY: gen-icons

--- a/crates/moss-themeconv/src/lib.rs
+++ b/crates/moss-themeconv/src/lib.rs
@@ -8,3 +8,5 @@ use anyhow::Result;
 pub trait ThemeConverter {
     fn convert_to_css(&self, content: String) -> Result<String>;
 }
+
+pub(crate) const DEFAULT_DIRECTION: &str = "to right";

--- a/crates/moss-themeconv/src/util.rs
+++ b/crates/moss-themeconv/src/util.rs
@@ -9,7 +9,11 @@ pub(crate) fn convert_colors_to_css_variables(
     convert_category_to_css_variables(category, colors, |color_detail| match &color_detail.value {
         ColorValue::Solid(val) => val.clone(),
         ColorValue::Gradient(vals) => {
-            let direction = color_detail.direction.as_deref().unwrap_or("to right");
+            let direction = color_detail
+                .direction
+                .as_deref()
+                .filter(|s| !s.is_empty())
+                .unwrap_or("to right");
 
             let gradient = vals
                 .iter()

--- a/crates/moss-themeconv/src/util.rs
+++ b/crates/moss-themeconv/src/util.rs
@@ -1,6 +1,6 @@
-use indexmap::IndexMap;
-
 use crate::model::*;
+use crate::DEFAULT_DIRECTION;
+use indexmap::IndexMap;
 
 pub(crate) fn convert_colors_to_css_variables(
     category: &str,
@@ -13,7 +13,7 @@ pub(crate) fn convert_colors_to_css_variables(
                 .direction
                 .as_deref()
                 .filter(|s| !s.is_empty())
-                .unwrap_or("to right");
+                .unwrap_or(DEFAULT_DIRECTION);
 
             let gradient = vals
                 .iter()

--- a/internal/workbench/desktop/models/schema/ThemeSchema.json
+++ b/internal/workbench/desktop/models/schema/ThemeSchema.json
@@ -73,34 +73,34 @@
         {
           "type": "object",
           "properties": {
-            "$type": {
+            "type": {
               "type": "string",
               "const": "solid"
             },
-            "$value": {
+            "value": {
               "$ref": "#/$defs/ColorTokenValue"
             }
           },
-          "required": ["$type", "$value"]
+          "required": ["type", "value"]
         },
         {
           "type": "object",
           "properties": {
-            "$type": {
+            "type": {
               "type": "string",
               "const": "gradient"
             },
-            "$direction": {
+            "direction": {
               "type": "string"
             },
-            "$value": {
+            "value": {
               "type": "array",
               "items": {
                 "$ref": "#/$defs/ColorGradientEntry"
               }
             }
           },
-          "required": ["$type", "$direction", "$value"]
+          "required": ["type", "direction", "value"]
         }
       ]
     },

--- a/internal/workbench/desktop/models/schema/TypeSpec.tsp
+++ b/internal/workbench/desktop/models/schema/TypeSpec.tsp
@@ -33,13 +33,13 @@ scalar ColorTokenValue extends string;
 
 union ColorType {
   {
-    "$type": "solid",
-    "$value": ColorTokenValue
+    "type": "solid",
+    "value": ColorTokenValue
   },
   {
-    "$type": "gradient",
-    "$direction": string,
-    "$value": ColorGradientEntry[]
+    "type": "gradient",
+    "direction": string,
+    "value": ColorGradientEntry[]
   }
 }
 

--- a/internal/workbench/desktop/models/schema/test.json
+++ b/internal/workbench/desktop/models/schema/test.json
@@ -5,9 +5,9 @@
   "isDefault": false,
   "color": {
     "primary": {
-      "$type": "gradient",
-      "$direction": "90deg",
-      "$value": [
+      "type": "gradient",
+      "direction": "90deg",
+      "value": [
         {
           "color": "rgba(0, 0, 0, 1)",
           "position": 0.25
@@ -18,14 +18,14 @@
         }
       ]
     },
-    "sideBar.background": { "$type": "solid", "$value": "rgba(255, 255, 255, 1)" },
-    "toolBar.background": { "$type": "solid", "$value": "rgb(255, 255, 255)" },
-    "page.background": { "$type": "solid", "$value": "#00ff00" },
-    "statusBar.background": { "$type": "solid", "$value": "hsla(9, 100%, 64%, 0.4)" },
-    "windowsCloseButton.background": { "$type": "solid", "$value": "hsl(0, 100%, 50%)" },
-    "windowControlsLinux.background": { "$type": "solid", "$value": "rgba(255, 255, 255, 1)" },
-    "windowControlsLinux.text": { "$type": "solid", "$value": "rgba(255, 255, 255, 1)" },
-    "windowControlsLinux.hoverBackground": { "$type": "solid", "$value": "rgba(255, 255, 255, 1)" },
-    "windowControlsLinux.activeBackground": { "$type": "solid", "$value": "rgba(255, 255, 255, 1)" }
+    "sideBar.background": { "type": "solid", "value": "rgba(255, 255, 255, 1)" },
+    "toolBar.background": { "type": "solid", "value": "rgb(255, 255, 255)" },
+    "page.background": { "type": "solid", "value": "#00ff00" },
+    "statusBar.background": { "type": "solid", "value": "hsla(9, 100%, 64%, 0.4)" },
+    "windowsCloseButton.background": { "type": "solid", "value": "hsl(0, 100%, 50%)" },
+    "windowControlsLinux.background": { "type": "solid", "value": "rgba(255, 255, 255, 1)" },
+    "windowControlsLinux.text": { "type": "solid", "value": "rgba(255, 255, 255, 1)" },
+    "windowControlsLinux.hoverBackground": { "type": "solid", "value": "rgba(255, 255, 255, 1)" },
+    "windowControlsLinux.activeBackground": { "type": "solid", "value": "rgba(255, 255, 255, 1)" }
   }
 }

--- a/internal/workbench/desktop/models/src/appearance.rs
+++ b/internal/workbench/desktop/models/src/appearance.rs
@@ -9,8 +9,6 @@ pub mod theming {
         Light,
         #[serde(rename = "dark")]
         Dark,
-        #[serde(rename = "pink")]
-        Pink,
     }
 
     #[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq, TS)]

--- a/internal/workbench/desktop/models/src/appearance.rs
+++ b/internal/workbench/desktop/models/src/appearance.rs
@@ -9,6 +9,8 @@ pub mod theming {
         Light,
         #[serde(rename = "dark")]
         Dark,
+        #[serde(rename = "pink")]
+        Pink,
     }
 
     #[derive(Deserialize, Serialize, Debug, Clone, Eq, PartialEq, TS)]

--- a/misc/themeinstall/Cargo.toml
+++ b/misc/themeinstall/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "themeinstall"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+moss_themeconv.workspace = true
+clap = { version = "4.5.21", features = ["derive"] }
+serde_json.workspace = true

--- a/misc/themeinstall/src/main.rs
+++ b/misc/themeinstall/src/main.rs
@@ -1,0 +1,41 @@
+use clap::Parser;
+use moss_themeconv::json_converter::JsonThemeConverter;
+use moss_themeconv::ThemeConverter;
+use serde_json::{from_reader, Value};
+use std::fs;
+use std::fs::File;
+use std::io::{BufReader, Write};
+use std::path::PathBuf;
+
+#[derive(Parser, Debug)]
+#[command(about)]
+struct InstallationArgs {
+    /// Path to the JSON file
+    #[arg(short, long)]
+    input: PathBuf,
+
+    /// Path to the output directory where the CSS file should be generated
+    #[arg(short, long)]
+    output: PathBuf,
+}
+
+fn main() {
+    let args = InstallationArgs::parse();
+    let converter = JsonThemeConverter::new();
+
+    let input_content = fs::read_to_string(&args.input).unwrap();
+    let input_json: Value = serde_json::from_str(&input_content).unwrap();
+
+    let output_name = input_json.get("slug").unwrap().as_str().unwrap();
+    let output_path = args.output.join(output_name).with_extension("css");
+    let output_css = converter.convert_to_css(input_content).unwrap();
+
+    let mut output_file = fs::File::create(&output_path).unwrap();
+    output_file.write_all(output_css.as_bytes()).unwrap();
+
+    println!(
+        "Successfully generate {} at {}",
+        output_name,
+        output_path.display()
+    );
+}

--- a/tools/themegen/src/index.ts
+++ b/tools/themegen/src/index.ts
@@ -14,16 +14,16 @@ const defaultDarkTheme: Theme = {
   type: "dark",
   isDefault: false,
   color: {
-    "primary": { "$type": "solid", "$value": "rgba(255, 255, 255, 1)" }, // prettier-ignore
-    "sideBar.background": { $type: "solid", $value: "rgba(39, 39, 42, 1)" },
-    "toolBar.background": { $type: "solid", $value: "rgba(30, 32, 33, 1)" },
-    "page.background": { $type: "solid", $value: "rgba(22, 24, 25, 1)" },
-    "statusBar.background": { $type: "solid", $value: "rgba(0, 122, 205, 1)" },
-    "windowsCloseButton.background": { $type: "solid", $value: "rgba(196, 43, 28, 1)" },
-    "windowControlsLinux.background": { $type: "solid", $value: "rgba(55, 55, 55, 1)" },
-    "windowControlsLinux.text": { $type: "solid", $value: "rgba(255, 255, 255, 1)" },
-    "windowControlsLinux.hoverBackground": { $type: "solid", $value: "rgba(66, 66, 66, 1)" },
-    "windowControlsLinux.activeBackground": { $type: "solid", $value: "rgba(86, 86, 86, 1)" },
+    "primary": { "type": "solid", "value": "rgba(255, 255, 255, 1)" }, // prettier-ignore
+    "sideBar.background": { type: "solid", value: "rgba(39, 39, 42, 1)" },
+    "toolBar.background": { type: "solid", value: "rgba(30, 32, 33, 1)" },
+    "page.background": { type: "solid", value: "rgba(22, 24, 25, 1)" },
+    "statusBar.background": { type: "solid", value: "rgba(0, 122, 205, 1)" },
+    "windowsCloseButton.background": { type: "solid", value: "rgba(196, 43, 28, 1)" },
+    "windowControlsLinux.background": { type: "solid", value: "rgba(55, 55, 55, 1)" },
+    "windowControlsLinux.text": { type: "solid", value: "rgba(255, 255, 255, 1)" },
+    "windowControlsLinux.hoverBackground": { type: "solid", value: "rgba(66, 66, 66, 1)" },
+    "windowControlsLinux.activeBackground": { type: "solid", value: "rgba(86, 86, 86, 1)" },
   },
 };
 
@@ -33,16 +33,16 @@ const defaultLightTheme: Theme = {
   type: "light",
   isDefault: true,
   color: {
-    "primary": { "$type": "solid", "$value": "rgba(0, 0, 0, 1)" }, // prettier-ignore
-    "sideBar.background": { $type: "solid", $value: "rgba(244, 244, 245, 1)" },
-    "toolBar.background": { $type: "solid", $value: "rgba(224, 224, 224, 1)" },
-    "page.background": { $type: "solid", $value: "rgba(255, 255, 255, 1)" },
-    "statusBar.background": { $type: "solid", $value: "rgba(0, 122, 205, 1)" },
-    "windowsCloseButton.background": { $type: "solid", $value: "rgba(196, 43, 28, 1)" },
-    "windowControlsLinux.background": { $type: "solid", $value: "rgba(218, 218, 218, 1)" },
-    "windowControlsLinux.text": { $type: "solid", $value: "rgba(61, 61, 61, 1)" },
-    "windowControlsLinux.hoverBackground": { $type: "solid", $value: "rgba(209, 209, 209, 1)" },
-    "windowControlsLinux.activeBackground": { $type: "solid", $value: "rgba(191, 191, 191, 1)" },
+    "primary": { "type": "solid", "value": "rgba(0, 0, 0, 1)" }, // prettier-ignore
+    "sideBar.background": { type: "solid", value: "rgba(244, 244, 245, 1)" },
+    "toolBar.background": { type: "solid", value: "rgba(224, 224, 224, 1)" },
+    "page.background": { type: "solid", value: "rgba(255, 255, 255, 1)" },
+    "statusBar.background": { type: "solid", value: "rgba(0, 122, 205, 1)" },
+    "windowsCloseButton.background": { type: "solid", value: "rgba(196, 43, 28, 1)" },
+    "windowControlsLinux.background": { type: "solid", value: "rgba(218, 218, 218, 1)" },
+    "windowControlsLinux.text": { type: "solid", value: "rgba(61, 61, 61, 1)" },
+    "windowControlsLinux.hoverBackground": { type: "solid", value: "rgba(209, 209, 209, 1)" },
+    "windowControlsLinux.activeBackground": { type: "solid", value: "rgba(191, 191, 191, 1)" },
   },
 };
 
@@ -54,16 +54,16 @@ const pinkTheme: Theme = {
   type: "pink",
   isDefault: false,
   color: {
-    "primary": { "$type": "solid", "$value": "rgba(0, 0, 0, 1)" }, // prettier-ignore
-    "sideBar.background": { $type: "solid", $value: "rgba(234, 157, 242, 1)" },
-    "toolBar.background": { $type: "solid", $value: "rgba(222, 125, 232, 1)" },
-    "page.background": { $type: "solid", $value: "rgba(227, 54, 245, 1)" },
-    "statusBar.background": { $type: "solid", $value: "rgba(63, 11, 69, 1)" },
-    "windowsCloseButton.background": { $type: "solid", $value: "rgba(196, 43, 28, 1)" },
-    "windowControlsLinux.background": { $type: "solid", $value: "rgba(218, 218, 218, 1)" },
-    "windowControlsLinux.text": { $type: "solid", $value: "rgba(61, 61, 61, 1)" },
-    "windowControlsLinux.hoverBackground": { $type: "solid", $value: "rgba(209, 209, 209, 1)" },
-    "windowControlsLinux.activeBackground": { $type: "solid", $value: "rgba(191, 191, 191, 1)" },
+    "primary": { "type": "solid", "value": "rgba(0, 0, 0, 1)" }, // prettier-ignore
+    "sideBar.background": { type: "solid", value: "rgba(234, 157, 242, 1)" },
+    "toolBar.background": { type: "solid", value: "rgba(222, 125, 232, 1)" },
+    "page.background": { type: "solid", value: "rgba(227, 54, 245, 1)" },
+    "statusBar.background": { type: "solid", value: "rgba(63, 11, 69, 1)" },
+    "windowsCloseButton.background": { type: "solid", value: "rgba(196, 43, 28, 1)" },
+    "windowControlsLinux.background": { type: "solid", value: "rgba(218, 218, 218, 1)" },
+    "windowControlsLinux.text": { type: "solid", value: "rgba(61, 61, 61, 1)" },
+    "windowControlsLinux.hoverBackground": { type: "solid", value: "rgba(209, 209, 209, 1)" },
+    "windowControlsLinux.activeBackground": { type: "solid", value: "rgba(191, 191, 191, 1)" },
   },
 };
 

--- a/tools/themegen/src/index.ts
+++ b/tools/themegen/src/index.ts
@@ -51,7 +51,7 @@ const defaultLightTheme: Theme = {
 const pinkTheme: Theme = {
   name: "Moss Pink",
   slug: "moss-pink",
-  type: "pink",
+  type: "light",
   isDefault: false,
   color: {
     "primary": { "type": "solid", "value": "rgba(0, 0, 0, 1)" }, // prettier-ignore


### PR DESCRIPTION
Develop a CLI utility that processes a JSON theme file and generates a corresponding CSS file based on the specified parameters.

After running `make gen-themes`, run `make install-themes` to convert themes JSON files into css files in the user's theme directory.