### PR TITLE
feat(MOSSMVP-293): Backend JSON logic validation logic

### DIFF
--- a/crates/moss-jsonlogic-macro/src/lib.rs
+++ b/crates/moss-jsonlogic-macro/src/lib.rs
@@ -12,6 +12,16 @@ pub fn rule(input: TokenStream) -> TokenStream {
     TokenStream::from(quote! { #rule })
 }
 
+#[proc_macro]
+pub fn rule_with_validation(input: TokenStream) -> TokenStream {
+    let expr = parse_macro_input!(input as Expr);
+    let rule_with_validation = match parse_expr_to_rule_with_validation(&expr) {
+        Ok(tokens) => tokens,
+        Err(e) => return TokenStream::from(e.to_compile_error()),
+    };
+    TokenStream::from(quote! { #rule_with_validation })
+}
+
 fn parse_expr_to_rule(expr: &Expr) -> syn::Result<proc_macro2::TokenStream> {
     match expr {
         Expr::Binary(expr_bin) => {
@@ -21,41 +31,41 @@ fn parse_expr_to_rule(expr: &Expr) -> syn::Result<proc_macro2::TokenStream> {
 
             let tokens = match op {
                 syn::BinOp::Add(_) => {
-                    quote! { #left.add(#right).map_err(|e| e.to_string()).unwrap() }
+                    quote! { #left.add(#right) }
                 }
                 syn::BinOp::Sub(_) => {
-                    quote! { #left.subtract(#right).map_err(|e| e.to_string()).unwrap() }
+                    quote! { #left.subtract(#right)}
                 }
                 syn::BinOp::Mul(_) => {
-                    quote! { #left.multiply(#right).map_err(|e| e.to_string()).unwrap() }
+                    quote! { #left.multiply(#right)}
                 }
                 syn::BinOp::Div(_) => {
-                    quote! { #left.divide(#right).map_err(|e| e.to_string()).unwrap() }
+                    quote! { #left.divide(#right)}
                 }
                 syn::BinOp::Rem(_) => {
-                    quote! { #left.modulo(#right).map_err(|e| e.to_string()).unwrap() }
+                    quote! { #left.modulo(#right)}
                 }
-                syn::BinOp::Eq(_) => quote! { #left.eq(#right).map_err(|e| e.to_string()).unwrap()},
+                syn::BinOp::Eq(_) => quote! { #left.eq(#right)},
                 syn::BinOp::Ne(_) => {
-                    quote! { #left.ne(#right).map_err(|e| e.to_string()).unwrap() }
+                    quote! { #left.ne(#right) }
                 }
                 syn::BinOp::Gt(_) => {
-                    quote! { #left.gt(#right).map_err(|e| e.to_string()).unwrap() }
+                    quote! { #left.gt(#right) }
                 }
                 syn::BinOp::Lt(_) => {
-                    quote! { #left.lt(#right).map_err(|e| e.to_string()).unwrap() }
+                    quote! { #left.lt(#right) }
                 }
                 syn::BinOp::Ge(_) => {
-                    quote! { #left.gte(#right).map_err(|e| e.to_string()).unwrap() }
+                    quote! { #left.gte(#right)}
                 }
                 syn::BinOp::Le(_) => {
-                    quote! { #left.lte(#right).map_err(|e| e.to_string()).unwrap() }
+                    quote! { #left.lte(#right) }
                 }
                 syn::BinOp::And(_) => {
-                    quote! { #left.and(#right).map_err(|e| e.to_string()).unwrap() }
+                    quote! { #left.and(#right) }
                 }
                 syn::BinOp::Or(_) => {
-                    quote! { #left.or(#right).map_err(|e| e.to_string()).unwrap() }
+                    quote! { #left.or(#right) }
                 }
                 _ => {
                     return Err(syn::Error::new_spanned(
@@ -70,7 +80,7 @@ fn parse_expr_to_rule(expr: &Expr) -> syn::Result<proc_macro2::TokenStream> {
             let operand = parse_expr_to_rule(&expr_unary.expr)?;
             let op = &expr_unary.op;
             let tokens = match op {
-                syn::UnOp::Not(_) => quote! { #operand.not().map_err(|e| e.to_string()).unwrap() },
+                syn::UnOp::Not(_) => quote! { #operand.not() },
                 _ => {
                     return Err(syn::Error::new_spanned(
                         op,
@@ -133,6 +143,136 @@ fn parse_expr_to_rule(expr: &Expr) -> syn::Result<proc_macro2::TokenStream> {
             let method_call = format!("{}.{}", receiver, method);
             Ok(quote! {
                 Rule::custom(#method_call, vec![#(#args),*])
+            })
+        }
+        _ => Err(syn::Error::new_spanned(
+            expr,
+            "Unsupported expression in rule macro",
+        )),
+    }
+}
+
+fn parse_expr_to_rule_with_validation(expr: &Expr) -> syn::Result<proc_macro2::TokenStream> {
+    match expr {
+        Expr::Binary(expr_bin) => {
+            let left = crate::parse_expr_to_rule_with_validation(&expr_bin.left)?;
+            let right = crate::parse_expr_to_rule_with_validation(&expr_bin.right)?;
+            let op = &expr_bin.op;
+
+            let tokens = match op {
+                syn::BinOp::Add(_) => {
+                    quote! { #left.add(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::Sub(_) => {
+                    quote! { #left.subtract(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::Mul(_) => {
+                    quote! { #left.multiply(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::Div(_) => {
+                    quote! { #left.divide(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::Rem(_) => {
+                    quote! { #left.modulo(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::Eq(_) => quote! { #left.eq(#right).map_err(|e| e.to_string()).unwrap()},
+                syn::BinOp::Ne(_) => {
+                    quote! { #left.ne(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::Gt(_) => {
+                    quote! { #left.gt(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::Lt(_) => {
+                    quote! { #left.lt(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::Ge(_) => {
+                    quote! { #left.gte(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::Le(_) => {
+                    quote! { #left.lte(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::And(_) => {
+                    quote! { #left.and(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::Or(_) => {
+                    quote! { #left.or(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                _ => {
+                    return Err(syn::Error::new_spanned(
+                        op,
+                        "Unsupported binary operator in rule macro",
+                    ))
+                }
+            };
+            Ok(tokens)
+        }
+        Expr::Unary(expr_unary) => {
+            let operand = crate::parse_expr_to_rule_with_validation(&expr_unary.expr)?;
+            let op = &expr_unary.op;
+            let tokens = match op {
+                syn::UnOp::Not(_) => quote! { #operand.not().map_err(|e| e.to_string()).unwrap() },
+                _ => {
+                    return Err(syn::Error::new_spanned(
+                        op,
+                        "Unsupported unary operator in rule macro",
+                    ))
+                }
+            };
+            Ok(tokens)
+        }
+        Expr::Paren(expr_paren) => crate::parse_expr_to_rule_with_validation(&expr_paren.expr),
+        Expr::Lit(expr_lit) => {
+            let lit = &expr_lit.lit;
+            match lit {
+                Lit::Int(_) | Lit::Float(_) | Lit::Str(_) | Lit::Bool(_) => {
+                    Ok(quote! { RuleWithValidation::value(#lit) })
+                }
+                _ => Err(syn::Error::new_spanned(
+                    lit,
+                    "Unsupported literal type in rule macro",
+                )),
+            }
+        }
+        Expr::Path(expr_path) => {
+            let ident = expr_path
+                .path
+                .get_ident()
+                .ok_or_else(|| syn::Error::new_spanned(expr_path, "Expected identifier"))?;
+            let name = ident.to_string();
+            Ok(quote! {
+                RuleWithValidation::var(#name)
+            })
+        }
+        Expr::Field(expr_field) => {
+            let base = parse_expr_to_string(&expr_field.base)?;
+            let member = match &expr_field.member {
+                Member::Named(ident) => ident.to_string(),
+                Member::Unnamed(index) => index.index.to_string(),
+            };
+            let full_name = format!("{}.{}", base, member);
+            Ok(quote! {
+                RuleWithValidation::var(#full_name)
+            })
+        }
+        Expr::Index(expr_index) => {
+            let base = parse_expr_to_string(&expr_index.expr)?;
+            let index = parse_expr_to_string(&expr_index.index)?;
+            let full_name = format!("{}[{}]", base, index);
+            Ok(quote! {
+                RuleWithValidation::var(#full_name)
+            })
+        }
+        Expr::MethodCall(expr_method_call) => {
+            let receiver = parse_expr_to_string(&expr_method_call.receiver)?;
+            let method = expr_method_call.method.to_string();
+            let args: Vec<_> = expr_method_call
+                .args
+                .iter()
+                .map(crate::parse_expr_to_rule_with_validation)
+                .collect::<Result<_, _>>()?;
+            let method_call = format!("{}.{}", receiver, method);
+            Ok(quote! {
+                RuleWithValidation::custom(#method_call, vec![#(#args),*])
             })
         }
         _ => Err(syn::Error::new_spanned(

--- a/crates/moss-jsonlogic-macro/src/lib.rs
+++ b/crates/moss-jsonlogic-macro/src/lib.rs
@@ -19,20 +19,44 @@ fn parse_expr_to_rule(expr: &Expr) -> syn::Result<proc_macro2::TokenStream> {
             let right = parse_expr_to_rule(&expr_bin.right)?;
             let op = &expr_bin.op;
 
-            let operator = match op {
-                syn::BinOp::Add(_) => quote! { Operator::Add },
-                syn::BinOp::Sub(_) => quote! { Operator::Subtract },
-                syn::BinOp::Mul(_) => quote! { Operator::Multiply },
-                syn::BinOp::Div(_) => quote! { Operator::Divide },
-                syn::BinOp::Rem(_) => quote! { Operator::Modulo },
-                syn::BinOp::Eq(_) => quote! { Operator::Equal },
-                syn::BinOp::Ne(_) => quote! { Operator::NotEqual },
-                syn::BinOp::Gt(_) => quote! { Operator::GreaterThan },
-                syn::BinOp::Lt(_) => quote! { Operator::LessThan },
-                syn::BinOp::Ge(_) => quote! { Operator::GreaterThanOrEqual },
-                syn::BinOp::Le(_) => quote! { Operator::LessThanOrEqual },
-                syn::BinOp::And(_) => quote! { Operator::And },
-                syn::BinOp::Or(_) => quote! { Operator::Or },
+            let tokens = match op {
+                syn::BinOp::Add(_) => {
+                    quote! { #left.add(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::Sub(_) => {
+                    quote! { #left.subtract(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::Mul(_) => {
+                    quote! { #left.multiply(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::Div(_) => {
+                    quote! { #left.divide(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::Rem(_) => {
+                    quote! { #left.modulo(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::Eq(_) => quote! { #left.eq(#right).map_err(|e| e.to_string()).unwrap()},
+                syn::BinOp::Ne(_) => {
+                    quote! { #left.ne(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::Gt(_) => {
+                    quote! { #left.gt(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::Lt(_) => {
+                    quote! { #left.lt(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::Ge(_) => {
+                    quote! { #left.gte(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::Le(_) => {
+                    quote! { #left.lte(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::And(_) => {
+                    quote! { #left.and(#right).map_err(|e| e.to_string()).unwrap() }
+                }
+                syn::BinOp::Or(_) => {
+                    quote! { #left.or(#right).map_err(|e| e.to_string()).unwrap() }
+                }
                 _ => {
                     return Err(syn::Error::new_spanned(
                         op,
@@ -40,37 +64,19 @@ fn parse_expr_to_rule(expr: &Expr) -> syn::Result<proc_macro2::TokenStream> {
                     ))
                 }
             };
-
-            let tokens = match op {
-                syn::BinOp::And(_) | syn::BinOp::Or(_) => {
-                    quote! {
-                        Rule::variadic(#operator, vec![#left, #right])
-                    }
-                }
-                _ => {
-                    quote! {
-                        Rule::binary(#operator, #left, #right)
-                    }
-                }
-            };
             Ok(tokens)
         }
         Expr::Unary(expr_unary) => {
             let operand = parse_expr_to_rule(&expr_unary.expr)?;
             let op = &expr_unary.op;
-
-            let operator = match op {
-                syn::UnOp::Not(_) => quote! { Operator::Not },
+            let tokens = match op {
+                syn::UnOp::Not(_) => quote! { #operand.not().map_err(|e| e.to_string()).unwrap() },
                 _ => {
                     return Err(syn::Error::new_spanned(
                         op,
                         "Unsupported unary operator in rule macro",
                     ))
                 }
-            };
-
-            let tokens = quote! {
-                Rule::unary(#operator, #operand)
             };
             Ok(tokens)
         }

--- a/crates/moss-jsonlogic/src/lib.rs
+++ b/crates/moss-jsonlogic/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod rule;
+mod rule_with_validation;

--- a/crates/moss-jsonlogic/src/rule.rs
+++ b/crates/moss-jsonlogic/src/rule.rs
@@ -1,59 +1,8 @@
-use crate::rule::TypeError::{IncompatibleType, InvalidType};
-use crate::rule::ValueError::ZeroDivision;
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize, Serializer};
 use serde_json::Value;
-use std::cmp::PartialEq;
 use std::fmt;
-use std::fmt::Display;
 use std::ops::{Add, BitAnd, BitOr, Div, Mul, Not, Sub};
-use thiserror::Error;
-
-#[derive(Debug, Error)]
-pub enum RuleError {
-    TypeError(TypeError),
-    ValueError(ValueError),
-}
-
-impl Display for RuleError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            RuleError::TypeError(e) => e.fmt(f),
-            RuleError::ValueError(e) => e.fmt(f),
-        }
-    }
-}
-
-#[derive(Debug, Error)]
-pub enum TypeError {
-    #[error("Operand '{operand:?}' have invalid type for operator '{operator}'")]
-    InvalidType { operator: Operator, operand: Rule },
-    #[error(
-        "Operand '{left:?}' has incompatible type with operand '{right:?}' for equality checks"
-    )]
-    IncompatibleType { left: Rule, right: Rule },
-}
-
-#[derive(Debug, Error)]
-pub enum ValueError {
-    #[error("Cannot divide by zero")]
-    ZeroDivision,
-}
-
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
-enum ResultType {
-    Number,
-    String,
-    Boolean,
-    Array,
-    Object,
-    Variable,
-    Undefined,
-}
-
-trait RuleType {
-    fn get_type(&self) -> ResultType;
-}
 
 /// Represents the standard JSON Logic operators.
 ///
@@ -171,41 +120,6 @@ impl fmt::Display for Operator {
         write!(f, "{}", op_str)
     }
 }
-
-impl RuleType for Operator {
-    fn get_type(&self) -> ResultType {
-        match self {
-            Operator::Equal => ResultType::Boolean,
-            Operator::NotEqual => ResultType::Boolean,
-            Operator::GreaterThan => ResultType::Boolean,
-            Operator::LessThan => ResultType::Boolean,
-            Operator::GreaterThanOrEqual => ResultType::Boolean,
-            Operator::LessThanOrEqual => ResultType::Boolean,
-            Operator::And => ResultType::Boolean,
-            Operator::Or => ResultType::Boolean,
-            Operator::Not => ResultType::Boolean,
-            Operator::Add => ResultType::Number,
-            Operator::Subtract => ResultType::Number,
-            Operator::Multiply => ResultType::Number,
-            Operator::Divide => ResultType::Number,
-            Operator::Modulo => ResultType::Number,
-            Operator::In => ResultType::Boolean,
-            Operator::Cat => ResultType::Undefined,
-            Operator::Map => ResultType::Variable,
-            Operator::Reduce => ResultType::Variable,
-            Operator::Filter => ResultType::Array,
-            Operator::All => ResultType::Boolean,
-            Operator::None => ResultType::Boolean,
-            Operator::Some => ResultType::Boolean,
-            Operator::Merge => ResultType::Array,
-            Operator::If => ResultType::Undefined,
-            Operator::Var => ResultType::Variable,
-            Operator::Missing => ResultType::Undefined,
-            Operator::MissingSome => ResultType::Undefined,
-        }
-    }
-}
-
 /// Represents a JSON Logic rule.
 ///
 /// The `Rule` enum is a comprehensive representation of all possible JSON Logic constructs,
@@ -310,49 +224,6 @@ pub enum Rule {
         operands: Vec<Rule>,
     },
 }
-
-impl RuleType for Rule {
-    fn get_type(&self) -> ResultType {
-        match self {
-            Rule::Constant(value) => match value {
-                Value::Null => ResultType::Undefined,
-                Value::Bool(_) => ResultType::Boolean,
-                Value::Number(_) => ResultType::Number,
-                Value::String(_) => ResultType::String,
-                Value::Array(_) => ResultType::Array,
-                Value::Object(_) => ResultType::Object,
-            },
-            Rule::Variable(_) => ResultType::Variable,
-            Rule::Unary { operator, .. } => operator.get_type(),
-            Rule::Binary { operator, .. } => operator.get_type(),
-            Rule::Variadic { operator, .. } => operator.get_type(),
-            Rule::Custom { .. } => ResultType::Variable,
-        }
-    }
-}
-
-impl Rule {
-    fn is_type_compatible_with(&self, other: &Rule) -> bool {
-        let self_type = self.get_type();
-        let other_type = other.get_type();
-        if self_type == other_type {
-            true
-        } else if self_type == ResultType::Variable || other_type == ResultType::Variable {
-            true
-        } else {
-            false
-        }
-    }
-
-    fn is_boolean_compatible(&self) -> bool {
-        self.get_type() == ResultType::Boolean || self.get_type() == ResultType::Variable
-    }
-
-    fn is_number_compatible(&self) -> bool {
-        self.get_type() == ResultType::Number || self.get_type() == ResultType::Variable
-    }
-}
-
 impl Rule {
     // ----------------------------------------------------------------------------
     // Constructor Methods
@@ -505,82 +376,6 @@ impl Rule {
     }
 
     // ----------------------------------------------------------------------------
-    // Validation Methods
-    //
-    // This section provides methods corresponding to specific operators, enabling
-    // the construction of logical, comparison, and arithmetic operations. These
-    // methods facilitate fluent and intuitive rule building through method chaining.
-    // ----------------------------------------------------------------------------
-    pub fn validate_boolean_operators(
-        operator: Operator,
-        operands: Vec<&Rule>,
-    ) -> Result<(), RuleError> {
-        let invalid_operands = operands
-            .iter()
-            .filter(|x| !x.is_boolean_compatible())
-            .collect::<Vec<_>>();
-        if invalid_operands.is_empty() {
-            Ok(())
-        } else {
-            Err(RuleError::TypeError(InvalidType {
-                operator,
-                operand: invalid_operands[0].to_owned().clone(),
-            }))
-        }
-    }
-
-    pub fn validate_equality_operators(left: &Rule, right: &Rule) -> Result<(), RuleError> {
-        if !left.is_type_compatible_with(right) {
-            return Err(RuleError::TypeError(IncompatibleType {
-                left: left.clone(),
-                right: right.clone(),
-            }));
-        }
-        Ok(())
-    }
-
-    pub fn validate_numeric_operators(
-        operator: Operator,
-        operands: Vec<&Rule>,
-    ) -> Result<(), RuleError> {
-        let invalid_operands = operands
-            .iter()
-            .filter(|x| !x.is_number_compatible())
-            .collect::<Vec<_>>();
-        if invalid_operands.is_empty() {
-            Ok(())
-        } else {
-            Err(RuleError::TypeError(InvalidType {
-                operator,
-                operand: invalid_operands[0].to_owned().clone(),
-            }))
-        }
-    }
-
-    pub fn validate_division(operator: Operator, right: &Rule) -> Result<(), RuleError> {
-        // For now we only check zero literal
-        // In the future, we can check expressions that evaluate to zero
-        if let Rule::Constant(divisor) = right.clone() {
-            if !divisor.is_number() {
-                return Err(RuleError::TypeError(InvalidType {
-                    operator,
-                    operand: right.clone(),
-                }));
-            }
-            let divisor = divisor.as_number().unwrap();
-            if divisor.is_f64() && divisor.as_f64().unwrap().abs() <= f64::EPSILON {
-                Err(RuleError::ValueError(ZeroDivision))
-            } else if divisor.is_i64() && divisor.as_i64().unwrap() == 0 {
-                Err(RuleError::ValueError(ZeroDivision))
-            } else {
-                Ok(())
-            }
-        } else {
-            Ok(())
-        }
-    }
-
-    // ----------------------------------------------------------------------------
     // Operator-Specific Methods
     //
     // This section provides methods corresponding to specific operators, enabling
@@ -599,9 +394,8 @@ impl Rule {
     ///
     /// let rule = Rule::var("is_active").not();
     /// ```
-    pub fn not(self) -> Result<Self, RuleError> {
-        Self::validate_boolean_operators(Operator::Not, vec![&self])?;
-        Ok(Rule::unary(Operator::Not, self))
+    pub fn not(self) -> Self {
+        Rule::unary(Operator::Not, self)
     }
 
     /// Logical AND operation.
@@ -617,20 +411,19 @@ impl Rule {
     ///
     /// let rule = Rule::var("is_admin").and(Rule::var("is_active"));
     /// ```
-    pub fn and(self, other: Self) -> Result<Self, RuleError> {
-        Self::validate_boolean_operators(Operator::And, vec![&self, &other])?;
+    pub fn and(self, other: Self) -> Self {
         match self {
             Rule::Variadic {
                 operator: Operator::And,
                 mut operands,
             } => {
                 operands.push(other);
-                Ok(Rule::Variadic {
+                Rule::Variadic {
                     operator: Operator::And,
                     operands,
-                })
+                }
             }
-            _ => Ok(Rule::variadic(Operator::And, vec![self, other])),
+            _ => Rule::variadic(Operator::And, vec![self, other]),
         }
     }
 
@@ -647,20 +440,19 @@ impl Rule {
     ///
     /// let rule = Rule::var("is_guest").or(Rule::var("is_banned"));
     /// ```
-    pub fn or(self, other: Self) -> Result<Self, RuleError> {
-        Self::validate_boolean_operators(Operator::Or, vec![&self, &other])?;
+    pub fn or(self, other: Self) -> Self {
         match self {
             Rule::Variadic {
                 operator: Operator::Or,
                 mut operands,
             } => {
                 operands.push(other);
-                Ok(Rule::Variadic {
+                Rule::Variadic {
                     operator: Operator::Or,
                     operands,
-                })
+                }
             }
-            _ => Ok(Rule::variadic(Operator::Or, vec![self, other])),
+            _ => Rule::variadic(Operator::Or, vec![self, other]),
         }
     }
 
@@ -675,9 +467,8 @@ impl Rule {
     ///
     /// let rule = Rule::var("role").eq(Rule::value("admin"));
     /// ```
-    pub fn eq(self, other: Self) -> Result<Self, RuleError> {
-        Self::validate_equality_operators(&self, &other)?;
-        Ok(Rule::binary(Operator::Equal, self, other))
+    pub fn eq(self, other: Self) -> Self {
+        Rule::binary(Operator::Equal, self, other)
     }
 
     /// Inequality comparison.
@@ -691,9 +482,8 @@ impl Rule {
     ///
     /// let rule = Rule::var("status").ne(Rule::value("inactive"));
     /// ```
-    pub fn ne(self, other: Self) -> Result<Self, RuleError> {
-        Self::validate_equality_operators(&self, &other)?;
-        Ok(Rule::binary(Operator::NotEqual, self, other))
+    pub fn ne(self, other: Self) -> Self {
+        Rule::binary(Operator::NotEqual, self, other)
     }
 
     /// Greater-than comparison.
@@ -707,9 +497,8 @@ impl Rule {
     ///
     /// let rule = Rule::var("score").gt(Rule::value(75));
     /// ```
-    pub fn gt(self, other: Self) -> Result<Self, RuleError> {
-        Self::validate_numeric_operators(Operator::GreaterThan, vec![&self, &other])?;
-        Ok(Rule::binary(Operator::GreaterThan, self, other))
+    pub fn gt(self, other: Self) -> Self {
+        Rule::binary(Operator::GreaterThan, self, other)
     }
 
     /// Less-than comparison.
@@ -723,9 +512,8 @@ impl Rule {
     ///
     /// let rule = Rule::var("age").lt(Rule::value(18));
     /// ```
-    pub fn lt(self, other: Self) -> Result<Self, RuleError> {
-        Self::validate_numeric_operators(Operator::LessThan, vec![&self, &other])?;
-        Ok(Rule::binary(Operator::LessThan, self, other))
+    pub fn lt(self, other: Self) -> Self {
+        Rule::binary(Operator::LessThan, self, other)
     }
 
     /// Greater-than-or-equal-to comparison.
@@ -739,9 +527,8 @@ impl Rule {
     ///
     /// let rule = Rule::var("experience").gte(Rule::value(5));
     /// ```
-    pub fn gte(self, other: Self) -> Result<Self, RuleError> {
-        Self::validate_numeric_operators(Operator::GreaterThanOrEqual, vec![&self, &other])?;
-        Ok(Rule::binary(Operator::GreaterThanOrEqual, self, other))
+    pub fn gte(self, other: Self) -> Self {
+        Rule::binary(Operator::GreaterThanOrEqual, self, other)
     }
 
     /// Less-than-or-equal-to comparison.
@@ -755,9 +542,8 @@ impl Rule {
     ///
     /// let rule = Rule::var("height").lte(Rule::value(180));
     /// ```
-    pub fn lte(self, other: Self) -> Result<Self, RuleError> {
-        Self::validate_numeric_operators(Operator::LessThanOrEqual, vec![&self, &other])?;
-        Ok(Rule::binary(Operator::LessThanOrEqual, self, other))
+    pub fn lte(self, other: Self) -> Self {
+        Rule::binary(Operator::LessThanOrEqual, self, other)
     }
 
     /// Addition operation.
@@ -773,20 +559,19 @@ impl Rule {
     ///
     /// let rule = Rule::var("quantity") + Rule::value(10);
     /// ```
-    pub fn add(self, other: Self) -> Result<Self, RuleError> {
-        Self::validate_numeric_operators(Operator::Add, vec![&self, &other])?;
+    pub fn add(self, other: Self) -> Self {
         match self {
             Rule::Variadic {
                 operator: Operator::Add,
                 mut operands,
             } => {
                 operands.push(other);
-                Ok(Rule::Variadic {
+                Rule::Variadic {
                     operator: Operator::Add,
                     operands,
-                })
+                }
             }
-            _ => Ok(Rule::variadic(Operator::Add, vec![self, other])),
+            _ => Rule::variadic(Operator::Add, vec![self, other]),
         }
     }
 
@@ -801,9 +586,8 @@ impl Rule {
     ///
     /// let rule = Rule::var("total") - Rule::value(20);
     /// ```
-    pub fn subtract(self, other: Self) -> Result<Self, RuleError> {
-        Self::validate_numeric_operators(Operator::Subtract, vec![&self, &other])?;
-        Ok(Rule::binary(Operator::Subtract, self, other))
+    pub fn subtract(self, other: Self) -> Self {
+        Rule::binary(Operator::Subtract, self, other)
     }
 
     /// Multiplication operation.
@@ -819,20 +603,19 @@ impl Rule {
     ///
     /// let rule = Rule::var("price") * Rule::value(2);
     /// ```
-    pub fn multiply(self, other: Self) -> Result<Self, RuleError> {
-        Self::validate_numeric_operators(Operator::Multiply, vec![&self, &other])?;
+    pub fn multiply(self, other: Self) -> Self {
         match self {
             Rule::Variadic {
                 operator: Operator::Multiply,
                 mut operands,
             } => {
                 operands.push(other);
-                Ok(Rule::Variadic {
+                Rule::Variadic {
                     operator: Operator::Multiply,
                     operands,
-                })
+                }
             }
-            _ => Ok(Rule::variadic(Operator::Multiply, vec![self, other])),
+            _ => Rule::variadic(Operator::Multiply, vec![self, other]),
         }
     }
 
@@ -847,10 +630,8 @@ impl Rule {
     ///
     /// let rule = Rule::var("total") / Rule::value(4);
     /// ```
-    pub fn divide(self, other: Self) -> Result<Self, RuleError> {
-        Self::validate_numeric_operators(Operator::Divide, vec![&self, &other])?;
-        Self::validate_division(Operator::Divide, &other)?;
-        Ok(Rule::binary(Operator::Divide, self, other))
+    pub fn divide(self, other: Self) -> Self {
+        Rule::binary(Operator::Divide, self, other)
     }
 
     /// Modulo operation.
@@ -864,10 +645,8 @@ impl Rule {
     ///
     /// let rule = Rule::var("number").modulo(Rule::value(3));
     /// ```
-    pub fn modulo(self, other: Self) -> Result<Self, RuleError> {
-        Self::validate_numeric_operators(Operator::Modulo, vec![&self, &other])?;
-        Self::validate_division(Operator::Modulo, &other)?;
-        Ok(Rule::binary(Operator::Modulo, self, other))
+    pub fn modulo(self, other: Self) -> Self {
+        Rule::binary(Operator::Modulo, self, other)
     }
 }
 
@@ -988,7 +767,7 @@ impl BitAnd for Rule {
     /// let rule = Rule::var("is_admin") & Rule::var("is_active");
     /// ```
     fn bitand(self, rhs: Rule) -> Rule {
-        self.and(rhs).unwrap()
+        self.and(rhs)
     }
 }
 
@@ -1005,7 +784,7 @@ impl BitOr for Rule {
     /// let rule = Rule::var("is_guest") | Rule::var("is_banned");
     /// ```
     fn bitor(self, rhs: Rule) -> Rule {
-        self.or(rhs).unwrap()
+        self.or(rhs)
     }
 }
 
@@ -1022,7 +801,7 @@ impl Add for Rule {
     /// let rule = Rule::var("quantity") + Rule::value(10);
     /// ```
     fn add(self, rhs: Rule) -> Rule {
-        self.add(rhs).unwrap()
+        self.add(rhs)
     }
 }
 
@@ -1039,7 +818,7 @@ impl Sub for Rule {
     /// let rule = Rule::var("total") - Rule::value(20);
     /// ```
     fn sub(self, rhs: Rule) -> Rule {
-        self.subtract(rhs).unwrap()
+        self.subtract(rhs)
     }
 }
 
@@ -1056,7 +835,7 @@ impl Mul for Rule {
     /// let rule = Rule::var("price") * Rule::value(2);
     /// ```
     fn mul(self, rhs: Rule) -> Rule {
-        self.multiply(rhs).unwrap()
+        self.multiply(rhs)
     }
 }
 
@@ -1073,7 +852,7 @@ impl Div for Rule {
     /// let rule = Rule::var("total") / Rule::value(4);
     /// ```
     fn div(self, rhs: Rule) -> Rule {
-        self.divide(rhs).unwrap()
+        self.divide(rhs)
     }
 }
 
@@ -1090,15 +869,14 @@ impl Not for Rule {
     /// let rule = !Rule::var("is_active");
     /// ```
     fn not(self) -> Rule {
-        self.not().unwrap()
+        self.not()
     }
 }
 
 #[cfg(test)]
-#[allow(unused_variables)]
 mod tests {
     use super::*;
-    use moss_jsonlogic_macro::rule;
+    use moss_jsonlogic_macro::{rule, rule_with_validation};
     use serde_json::json;
 
     /// Tests arithmetic operations and their serialization.
@@ -1112,7 +890,7 @@ mod tests {
         let const_ten = Rule::value(10);
 
         // Build rule: (x + y) > 10
-        let rule = (var_x + var_y).gt(const_ten).unwrap();
+        let rule = (var_x + var_y).gt(const_ten);
 
         // Serialize to JSON Logic
         let json_logic =
@@ -1136,7 +914,7 @@ mod tests {
         let const_active = Rule::from("active");
 
         // Build rule: !(status == "active")
-        let rule = !(var_status.eq(const_active).unwrap());
+        let rule = !(var_status.eq(const_active));
 
         // Serialize to JSON Logic
         let json_logic =
@@ -1166,9 +944,9 @@ mod tests {
         let const_twenty = Rule::from(20);
 
         // Build rules
-        let rule1 = var_x.gt(const_five).unwrap(); // x > 5
-        let rule2 = var_y.lt(const_ten).unwrap(); // y < 10
-        let rule3 = var_z.eq(const_twenty).unwrap(); // z == 20
+        let rule1 = var_x.gt(const_five); // x > 5
+        let rule2 = var_y.lt(const_ten); // y < 10
+        let rule3 = var_z.eq(const_twenty); // z == 20
 
         // Combine rules: (x > 5 AND y < 10) OR z == 20
         let combined_rule = (rule1 & rule2) | rule3;
@@ -1228,7 +1006,7 @@ mod tests {
         let const_threshold = Rule::from(100);
 
         // Build rule: (score + bonus) >= 100
-        let rule = (var_score + var_bonus).gte(const_threshold).unwrap();
+        let rule = (var_score + var_bonus).gte(const_threshold);
 
         // Serialize to JSON Logic
         let json_logic =
@@ -1257,7 +1035,7 @@ mod tests {
         let const_three = Rule::value(3);
 
         // Build rule: !(status == "locked" || attempts > 3)
-        let rule = !(var_status.eq(const_locked).unwrap() | var_attempts.gt(const_three).unwrap());
+        let rule = !(var_status.eq(const_locked) | var_attempts.gt(const_three));
 
         // Serialize to JSON Logic
         let json_logic =
@@ -1347,9 +1125,9 @@ mod tests {
         let const_three = Rule::value(3);
 
         let rule_sum = var_x + var_y; // x + y
-        let rule_gt = rule_sum.gt(const_ten).unwrap(); // (x + y) > 10
-        let rule_le = var_z.lte(const_five).unwrap(); // z <= 5
-        let rule_ne = var_w.ne(const_three).unwrap(); // w != 3
+        let rule_gt = rule_sum.gt(const_ten); // (x + y) > 10
+        let rule_le = var_z.lte(const_five); // z <= 5
+        let rule_ne = var_w.ne(const_three); // w != 3
         let rule_or = rule_le | rule_ne; // (z <= 5 OR w != 3)
         let combined_rule = rule_gt & rule_or; // (x + y) > 10 AND (z <= 5 OR w != 3)
 
@@ -1388,8 +1166,7 @@ mod tests {
         let const_max_attempts = Rule::from(3);
 
         // Build rule: !(status == "locked" || attempts > 3)
-        let rule =
-            !(var_status.eq(const_locked).unwrap() | var_attempts.gt(const_max_attempts).unwrap());
+        let rule = !(var_status.eq(const_locked) | var_attempts.gt(const_max_attempts));
 
         // Serialize to JSON Logic
         let json_logic =
@@ -1417,9 +1194,9 @@ mod tests {
         let var_b = Rule::var("b");
         let var_c = Rule::var("c");
 
-        let rule1 = var_a.eq(Rule::from(5)).unwrap();
-        let rule2 = var_b.gt(Rule::from(10)).unwrap();
-        let rule3 = var_c.lt(Rule::from(20)).unwrap();
+        let rule1 = var_a.eq(Rule::from(5));
+        let rule2 = var_b.gt(Rule::from(10));
+        let rule3 = var_c.lt(Rule::from(20));
 
         // Combine rules using logical operators
         let combined_rule = rule1 & (rule2 | rule3);
@@ -1458,13 +1235,7 @@ mod tests {
     fn test_rule_with_desired_api() {
         let rule = Rule::var("view")
             .eq(Rule::value("recents.view.id"))
-            .unwrap()
-            .and(
-                Rule::var("viewItem")
-                    .eq(Rule::value("recents.item"))
-                    .unwrap(),
-            )
-            .unwrap();
+            .and(Rule::var("viewItem").eq(Rule::value("recents.item")));
 
         let json_logic =
             serde_json::to_value(rule).expect("Failed to serialize the rule into JSON.");
@@ -1592,9 +1363,7 @@ mod tests {
     fn test_method_chaining() {
         let rule = Rule::var("age")
             .gte(Rule::value(18))
-            .unwrap()
-            .and(Rule::var("status").eq(Rule::value("active")).unwrap())
-            .unwrap();
+            .and(Rule::var("status").eq(Rule::value("active")));
 
         let json_logic =
             serde_json::to_value(rule).expect("Failed to serialize the rule into JSON.");
@@ -1623,9 +1392,7 @@ mod tests {
     fn test_rule_with_variables_and_values() {
         let rule = Rule::var("status")
             .ne(Rule::value("inactive"))
-            .unwrap()
-            .and(Rule::var("age").gte(Rule::value(18)).unwrap())
-            .unwrap();
+            .and(Rule::var("age").gte(Rule::value(18)));
 
         let json_logic =
             serde_json::to_value(rule).expect("Failed to serialize the rule into JSON.");
@@ -1667,18 +1434,6 @@ mod tests {
             json!({ ">": [{ "var": "age" }, 18] })
         );
     }
-    // TODO: Flatten variadic operators
-    // +, -, && and ||
-    // (Without flattening)
-    // 1 + 2 + 3 => {
-    //     "+": [
-    //         {"+": [1, 2]},
-    //         3
-    //     ]
-    // }
-    // (With flattening)
-    // 1 + 2 + 3 => {
-    //     "+": [1, 2, 3]
 
     #[test]
     fn test_rule_macro_simple_variadic() {
@@ -1737,134 +1492,5 @@ mod tests {
                 ]
             })
         );
-    }
-
-    /// --------------------
-    /// Validation test
-    /// --------------------
-
-    #[test]
-    #[should_panic]
-    fn test_invalid_type_not() {
-        let rule = rule!(!"1");
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_invalid_type_and() {
-        let rule = rule!(1 && true);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_invalid_type_or() {
-        let rule = rule!("1" || true);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_incompatible_type_eq() {
-        let rule = rule!(1 == "1");
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_incompatible_type_ne() {
-        let rule = rule!(true != "false");
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_invalid_type_gt() {
-        let rule = rule!("42" > 0);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_invalid_type_lt() {
-        let rule = rule!(false < true);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_invalid_type_gte() {
-        let rule = rule!("42" >= 42);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_invalid_type_lte() {
-        let rule = rule!(42 <= "42");
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_invalid_type_add() {
-        let rule = rule!(true + "true");
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_invalid_type_subtract() {
-        let rule = rule!("1" - 1);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_invalid_type_multiply() {
-        let rule = rule!("1" * 2);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_invalid_type_divide() {
-        let rule = rule!("foo" / "bar");
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_invalid_type_modulo() {
-        let rule = rule!("3" % "2");
-    }
-    #[test]
-    #[should_panic]
-    fn test_zero_division_divide() {
-        let rule = rule!(42 / 0);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_zero_division_modulo() {
-        let rule = rule!(42 % 0.0);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_invalid_type_compound1() {
-        let rule = rule!(1 + 2 / "3");
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_invalid_type_compound2() {
-        let rule = rule!(x - true * false);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_invalid_type_compound3() {
-        let rule = rule!(x && !"true");
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_invalid_type_compound4() {
-        let rule = rule!(42 > 0 < 1);
-    }
-
-    #[test]
-    #[should_panic]
-    fn test_invalid_type_compound5() {
-        let rule = rule!(3.14 < 159 - "26");
     }
 }

--- a/crates/moss-jsonlogic/src/rule_with_validation.rs
+++ b/crates/moss-jsonlogic/src/rule_with_validation.rs
@@ -1,0 +1,1171 @@
+use crate::rule::{Operator, Rule};
+use serde::{Deserialize, Serialize, Serializer};
+use serde_json::Value;
+use std::fmt::{Debug, Display};
+use std::ops::Not;
+use std::ops::{Add, BitAnd, BitOr, Div, Mul, Sub};
+use thiserror::Error;
+
+// TODO: update documentation
+
+#[derive(Debug, Error)]
+pub enum RuleError {
+    #[error("Operand '{operand:?}' have invalid type for operator '{operator}'")]
+    InvalidType { operator: Operator, operand: Rule },
+    #[error(
+        "Operand '{left:?}' has incompatible type with operand '{right:?}' for equality checks"
+    )]
+    IncompatibleType { left: Rule, right: Rule },
+    #[error("Cannot divide by zero")]
+    ZeroDivision,
+}
+
+#[derive(Serialize, Deserialize, Debug, PartialEq, Clone)]
+enum ResultType {
+    Number,
+    String,
+    Boolean,
+    Array,
+    Object,
+    Variable,
+    Undefined,
+}
+
+trait RuleType {
+    fn get_type(&self) -> ResultType;
+}
+
+impl RuleType for Operator {
+    fn get_type(&self) -> ResultType {
+        match self {
+            Operator::Equal => ResultType::Boolean,
+            Operator::NotEqual => ResultType::Boolean,
+            Operator::GreaterThan => ResultType::Boolean,
+            Operator::LessThan => ResultType::Boolean,
+            Operator::GreaterThanOrEqual => ResultType::Boolean,
+            Operator::LessThanOrEqual => ResultType::Boolean,
+            Operator::And => ResultType::Boolean,
+            Operator::Or => ResultType::Boolean,
+            Operator::Not => ResultType::Boolean,
+            Operator::Add => ResultType::Number,
+            Operator::Subtract => ResultType::Number,
+            Operator::Multiply => ResultType::Number,
+            Operator::Divide => ResultType::Number,
+            Operator::Modulo => ResultType::Number,
+            Operator::In => ResultType::Boolean,
+            Operator::Cat => ResultType::Undefined,
+            Operator::Map => ResultType::Variable,
+            Operator::Reduce => ResultType::Variable,
+            Operator::Filter => ResultType::Array,
+            Operator::All => ResultType::Boolean,
+            Operator::None => ResultType::Boolean,
+            Operator::Some => ResultType::Boolean,
+            Operator::Merge => ResultType::Array,
+            Operator::If => ResultType::Undefined,
+            Operator::Var => ResultType::Variable,
+            Operator::Missing => ResultType::Undefined,
+            Operator::MissingSome => ResultType::Undefined,
+        }
+    }
+}
+
+pub struct RuleWithValidation {
+    rule: Rule,
+}
+
+impl From<Rule> for RuleWithValidation {
+    fn from(rule: Rule) -> Self {
+        RuleWithValidation { rule }
+    }
+}
+
+impl RuleType for RuleWithValidation {
+    fn get_type(&self) -> ResultType {
+        match &self.rule {
+            Rule::Constant(value) => match value {
+                Value::Null => ResultType::Undefined,
+                Value::Bool(_) => ResultType::Boolean,
+                Value::Number(_) => ResultType::Number,
+                Value::String(_) => ResultType::String,
+                Value::Array(_) => ResultType::Array,
+                Value::Object(_) => ResultType::Object,
+            },
+            Rule::Variable(_) => ResultType::Variable,
+            Rule::Unary { operator, .. } => operator.get_type(),
+            Rule::Binary { operator, .. } => operator.get_type(),
+            Rule::Variadic { operator, .. } => operator.get_type(),
+            Rule::Custom { .. } => ResultType::Variable,
+        }
+    }
+}
+
+impl RuleWithValidation {
+    // ----------------------------------------------------------------------------
+    // Role Methods
+    // ----------------------------------------------------------------------------
+    fn is_type_compatible_with(&self, other: &RuleWithValidation) -> bool {
+        let self_type = self.get_type();
+        let other_type = other.get_type();
+        if self_type == other_type {
+            true
+        } else if self_type == ResultType::Variable || other_type == ResultType::Variable {
+            true
+        } else {
+            false
+        }
+    }
+
+    fn is_boolean_compatible(&self) -> bool {
+        self.get_type() == ResultType::Boolean || self.get_type() == ResultType::Variable
+    }
+
+    fn is_number_compatible(&self) -> bool {
+        self.get_type() == ResultType::Number || self.get_type() == ResultType::Variable
+    }
+
+    // ----------------------------------------------------------------------------
+    // Validation Methods
+    // ----------------------------------------------------------------------------
+    pub fn validate_boolean_operators(
+        operator: Operator,
+        operands: Vec<&RuleWithValidation>,
+    ) -> Result<(), RuleError> {
+        let invalid_operands = operands
+            .iter()
+            .filter(|x| !x.is_boolean_compatible())
+            .collect::<Vec<_>>();
+        if invalid_operands.is_empty() {
+            Ok(())
+        } else {
+            Err(RuleError::InvalidType {
+                operator,
+                operand: invalid_operands[0].rule.clone(),
+            })
+        }
+    }
+
+    pub fn validate_equality_operators(
+        left: &RuleWithValidation,
+        right: &RuleWithValidation,
+    ) -> Result<(), RuleError> {
+        if !left.is_type_compatible_with(right) {
+            return Err(RuleError::IncompatibleType {
+                left: left.rule.clone(),
+                right: right.rule.clone(),
+            });
+        }
+        Ok(())
+    }
+
+    pub fn validate_numeric_operators(
+        operator: Operator,
+        operands: Vec<&RuleWithValidation>,
+    ) -> Result<(), RuleError> {
+        let invalid_operands = operands
+            .iter()
+            .filter(|x| !x.is_number_compatible())
+            .collect::<Vec<_>>();
+        if invalid_operands.is_empty() {
+            Ok(())
+        } else {
+            Err(RuleError::InvalidType {
+                operator,
+                operand: invalid_operands[0].rule.clone(),
+            })
+        }
+    }
+
+    pub fn validate_division(
+        operator: Operator,
+        right: &RuleWithValidation,
+    ) -> Result<(), RuleError> {
+        // For now we only check zero literal
+        // In the future, we can check expressions that evaluate to zero
+        if let Rule::Constant(divisor) = right.rule.clone() {
+            if !divisor.is_number() {
+                return Err(RuleError::InvalidType {
+                    operator,
+                    operand: right.rule.clone(),
+                });
+            }
+            let divisor = divisor.as_number().unwrap();
+            if divisor.is_f64() && divisor.as_f64().unwrap().abs() <= f64::EPSILON {
+                Err(RuleError::ZeroDivision)
+            } else if divisor.is_i64() && divisor.as_i64().unwrap() == 0 {
+                Err(RuleError::ZeroDivision)
+            } else {
+                Ok(())
+            }
+        } else {
+            Ok(())
+        }
+    }
+    // ----------------------------------------------------------------------------
+    // Constructor Methods
+    // ----------------------------------------------------------------------------
+    pub fn value<V: Into<Value>>(value: V) -> Self {
+        Rule::Constant(value.into()).into()
+    }
+
+    pub fn constant<V: Into<Value>>(value: V) -> Self {
+        Rule::Constant(value.into()).into()
+    }
+
+    pub fn var<S: Into<String>>(name: S) -> Self {
+        Rule::Variable(name.into()).into()
+    }
+
+    pub fn custom<S: Into<String>>(operator: S, operands: Vec<Self>) -> Self {
+        Rule::Custom {
+            operator: operator.into(),
+            operands: operands.into_iter().map(|x| x.rule).collect(),
+        }
+        .into()
+    }
+
+    // ----------------------------------------------------------------------------
+    // Operator-Specific Methods
+    // ----------------------------------------------------------------------------
+
+    pub fn not(self) -> Result<Self, RuleError> {
+        Self::validate_boolean_operators(Operator::Not, vec![&self])?;
+        Ok(self.rule.not().into())
+    }
+
+    pub fn and(self, other: Self) -> Result<Self, RuleError> {
+        Self::validate_boolean_operators(Operator::And, vec![&self, &other])?;
+        Ok(self.rule.and(other.rule).into())
+    }
+
+    pub fn or(self, other: Self) -> Result<Self, RuleError> {
+        Self::validate_boolean_operators(Operator::Or, vec![&self, &other])?;
+        Ok(self.rule.or(other.rule).into())
+    }
+
+    pub fn eq(self, other: Self) -> Result<Self, RuleError> {
+        Self::validate_equality_operators(&self, &other)?;
+        Ok(self.rule.eq(other.rule).into())
+    }
+
+    pub fn ne(self, other: Self) -> Result<Self, RuleError> {
+        Self::validate_equality_operators(&self, &other)?;
+        Ok(self.rule.ne(other.rule).into())
+    }
+
+    pub fn gt(self, other: Self) -> Result<Self, RuleError> {
+        Self::validate_numeric_operators(Operator::GreaterThan, vec![&self, &other])?;
+        Ok(self.rule.gt(other.rule).into())
+    }
+
+    pub fn lt(self, other: Self) -> Result<Self, RuleError> {
+        Self::validate_numeric_operators(Operator::LessThan, vec![&self, &other])?;
+        Ok(self.rule.lt(other.rule).into())
+    }
+
+    pub fn gte(self, other: Self) -> Result<Self, RuleError> {
+        Self::validate_numeric_operators(Operator::GreaterThanOrEqual, vec![&self, &other])?;
+        Ok(self.rule.gte(other.rule).into())
+    }
+
+    pub fn lte(self, other: Self) -> Result<Self, RuleError> {
+        Self::validate_numeric_operators(Operator::LessThanOrEqual, vec![&self, &other])?;
+        Ok(self.rule.lte(other.rule).into())
+    }
+
+    pub fn add(self, other: Self) -> Result<Self, RuleError> {
+        Self::validate_numeric_operators(Operator::Add, vec![&self, &other])?;
+        Ok(self.rule.add(other.rule).into())
+    }
+
+    pub fn subtract(self, other: Self) -> Result<Self, RuleError> {
+        Self::validate_numeric_operators(Operator::Subtract, vec![&self, &other])?;
+        Ok(self.rule.subtract(other.rule).into())
+    }
+
+    pub fn multiply(self, other: Self) -> Result<Self, RuleError> {
+        Self::validate_numeric_operators(Operator::Multiply, vec![&self, &other])?;
+        Ok(self.rule.multiply(other.rule).into())
+    }
+    pub fn divide(self, other: Self) -> Result<Self, RuleError> {
+        Self::validate_numeric_operators(Operator::Divide, vec![&self, &other])?;
+        Self::validate_division(Operator::Divide, &other)?;
+        Ok(self.rule.divide(other.rule).into())
+    }
+
+    pub fn modulo(self, other: Self) -> Result<Self, RuleError> {
+        Self::validate_numeric_operators(Operator::Modulo, vec![&self, &other])?;
+        Self::validate_division(Operator::Modulo, &other)?;
+        Ok(self.rule.modulo(other.rule).into())
+    }
+}
+
+impl Serialize for RuleWithValidation {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.rule.serialize(serializer)
+    }
+}
+
+impl From<&str> for RuleWithValidation {
+    fn from(s: &str) -> Self {
+        Rule::constant(s).into()
+    }
+}
+
+impl From<String> for RuleWithValidation {
+    fn from(s: String) -> Self {
+        Rule::constant(s).into()
+    }
+}
+
+impl From<i64> for RuleWithValidation {
+    fn from(n: i64) -> Self {
+        Rule::constant(n).into()
+    }
+}
+
+impl From<f64> for RuleWithValidation {
+    fn from(n: f64) -> Self {
+        Rule::constant(n).into()
+    }
+}
+
+impl From<bool> for RuleWithValidation {
+    fn from(b: bool) -> Self {
+        Rule::constant(b).into()
+    }
+}
+
+impl From<Value> for RuleWithValidation {
+    fn from(value: Value) -> Self {
+        Rule::constant(value).into()
+    }
+}
+
+impl BitAnd for RuleWithValidation {
+    type Output = RuleWithValidation;
+
+    fn bitand(self, rhs: RuleWithValidation) -> RuleWithValidation {
+        self.and(rhs).map_err(|e| e.to_string()).unwrap()
+    }
+}
+
+impl BitOr for RuleWithValidation {
+    type Output = RuleWithValidation;
+
+    fn bitor(self, rhs: RuleWithValidation) -> RuleWithValidation {
+        self.or(rhs).map_err(|e| e.to_string()).unwrap()
+    }
+}
+
+impl Add for RuleWithValidation {
+    type Output = RuleWithValidation;
+
+    fn add(self, rhs: RuleWithValidation) -> RuleWithValidation {
+        self.add(rhs).map_err(|e| e.to_string()).unwrap()
+    }
+}
+
+impl Sub for RuleWithValidation {
+    type Output = RuleWithValidation;
+
+    fn sub(self, rhs: RuleWithValidation) -> RuleWithValidation {
+        self.subtract(rhs).map_err(|e| e.to_string()).unwrap()
+    }
+}
+
+impl Mul for RuleWithValidation {
+    type Output = RuleWithValidation;
+    fn mul(self, rhs: RuleWithValidation) -> RuleWithValidation {
+        self.multiply(rhs).map_err(|e| e.to_string()).unwrap()
+    }
+}
+
+impl Div for RuleWithValidation {
+    type Output = RuleWithValidation;
+    fn div(self, rhs: RuleWithValidation) -> RuleWithValidation {
+        self.divide(rhs).map_err(|e| e.to_string()).unwrap()
+    }
+}
+
+impl Not for RuleWithValidation {
+    type Output = RuleWithValidation;
+
+    fn not(self) -> RuleWithValidation {
+        self.not().map_err(|e| e.to_string()).unwrap()
+    }
+}
+
+mod tests {
+    use super::*;
+    use moss_jsonlogic_macro::rule_with_validation;
+    use serde_json::json;
+
+    /// ----------------------------------------------------------------------------
+    /// Basic Tests
+    ///
+    /// Ensure that `RuleWithValidation` has consistent behaviors with `Rule`
+    /// ----------------------------------------------------------------------------
+    #[test]
+    fn test_arithmetic_operations() {
+        let var_x = RuleWithValidation::var("x");
+        let var_y = RuleWithValidation::var("y");
+
+        let const_ten = RuleWithValidation::value(10);
+
+        // Build rule: (x + y) > 10
+        let rule = (var_x + var_y).gt(const_ten).unwrap();
+
+        // Serialize to JSON Logic
+        let json_logic =
+            serde_json::to_value(rule).expect("Failed to serialize the rule into JSON.");
+
+        // Expected JSON Logic
+        let expected_json = json!({
+            ">": [
+                { "+": [ { "var": "x" }, { "var": "y" } ] },
+                10
+            ]
+        });
+
+        assert_eq!(json_logic, expected_json);
+    }
+
+    #[test]
+    fn test_logical_not() {
+        let var_status = RuleWithValidation::var("status");
+
+        let const_active = RuleWithValidation::from("active");
+
+        // Build rule: !(status == "active")
+        let rule = !(var_status.eq(const_active).unwrap());
+
+        // Serialize to JSON Logic
+        let json_logic =
+            serde_json::to_value(rule).expect("Failed to serialize the rule into JSON.");
+
+        // Expected JSON Logic
+        let expected_json = json!({
+            "!": {
+                "==": [
+                    { "var": "status" },
+                    "active"
+                ]
+            }
+        });
+
+        assert_eq!(json_logic, expected_json);
+    }
+
+    #[test]
+    fn test_complex_nested_rules() {
+        let var_x = RuleWithValidation::var("x");
+        let var_y = RuleWithValidation::var("y");
+        let var_z = RuleWithValidation::var("z");
+
+        let const_five = RuleWithValidation::from(5);
+        let const_ten = RuleWithValidation::from(10);
+        let const_twenty = RuleWithValidation::from(20);
+
+        // Build rules
+        let rule1 = var_x.gt(const_five).unwrap(); // x > 5
+        let rule2 = var_y.lt(const_ten).unwrap(); // y < 10
+        let rule3 = var_z.eq(const_twenty).unwrap(); // z == 20
+
+        // Combine rules: (x > 5 AND y < 10) OR z == 20
+        let combined_rule = (rule1 & rule2) | rule3;
+
+        // Serialize to JSON Logic
+        let json_logic =
+            serde_json::to_value(combined_rule).expect("Failed to serialize the rule into JSON.");
+
+        // Expected JSON Logic
+        let expected_json = json!({
+            "or": [
+                {
+                    "and": [
+                        { ">": [ { "var": "x" }, 5 ] },
+                        { "<": [ { "var": "y" }, 10 ] }
+                    ]
+                },
+                { "==": [ { "var": "z" }, 20 ] }
+            ]
+        });
+
+        assert_eq!(json_logic, expected_json);
+    }
+
+    #[test]
+    fn test_chained_arithmetic_operations() {
+        let var_a = RuleWithValidation::var("a");
+        let var_b = RuleWithValidation::var("b");
+        let var_c = RuleWithValidation::var("c");
+
+        // Build rule: (a * b) + c
+        let arithmetic_rule = (var_a * var_b) + var_c;
+
+        // Serialize to JSON Logic
+        let json_logic =
+            serde_json::to_value(arithmetic_rule).expect("Failed to serialize the rule into JSON.");
+
+        // Expected JSON Logic
+        let expected_json = json!({
+            "+": [
+                { "*": [ { "var": "a" }, { "var": "b" } ] },
+                { "var": "c" }
+            ]
+        });
+
+        assert_eq!(json_logic, expected_json);
+    }
+
+    /// Tests the combination of logical and arithmetic operations with operator overloading.
+    ///
+    /// Constructs a rule that checks if `(x * y) + z <= 100`.
+    #[test]
+    fn test_combining_logical_and_arithmetic_operations() {
+        let var_score = RuleWithValidation::var("score");
+        let var_bonus = RuleWithValidation::var("bonus");
+
+        let const_threshold = RuleWithValidation::from(100);
+
+        // Build rule: (score + bonus) >= 100
+        let rule = (var_score + var_bonus).gte(const_threshold).unwrap();
+
+        // Serialize to JSON Logic
+        let json_logic =
+            serde_json::to_value(rule).expect("Failed to serialize the rule into JSON.");
+
+        // Expected JSON Logic
+        let expected_json = json!({
+            ">=": [
+                { "+": [ { "var": "score" }, { "var": "bonus" } ] },
+                100
+            ]
+        });
+
+        assert_eq!(json_logic, expected_json);
+    }
+
+    /// Tests complex nested rules involving logical NOT and operator overloading.
+    ///
+    /// Constructs a rule that represents `!(status == "locked" || attempts > 3)`.
+    #[test]
+    fn test_complex_nested_rules_with_not() {
+        let var_status = RuleWithValidation::var("status");
+        let var_attempts = RuleWithValidation::var("attempts");
+
+        let const_locked = RuleWithValidation::value("locked");
+        let const_three = RuleWithValidation::value(3);
+
+        // Build rule: !(status == "locked" || attempts > 3)
+        let rule = !(var_status.eq(const_locked).unwrap() | var_attempts.gt(const_three).unwrap());
+
+        // Serialize to JSON Logic
+        let json_logic =
+            serde_json::to_value(rule).expect("Failed to serialize the rule into JSON.");
+
+        // Define the expected JSON Logic
+        let expected_json = json!({
+            "!": {
+                "or": [
+                    { "==": [ { "var": "status" }, "locked" ] },
+                    { ">": [ { "var": "attempts" }, 3 ] }
+                ]
+            }
+        });
+
+        // Assert that the serialized JSON matches the expected JSON
+        assert_eq!(json_logic, expected_json);
+    }
+
+    /// Tests serialization of rules with multiple arithmetic operations.
+    ///
+    /// Constructs a rule that represents `(a * b) + (c / d) - e`.
+    #[test]
+    fn test_multiple_arithmetic_operations() {
+        let var_a = RuleWithValidation::var("a");
+        let var_b = RuleWithValidation::var("b");
+        let var_c = RuleWithValidation::var("c");
+        let var_d = RuleWithValidation::var("d");
+        let var_e = RuleWithValidation::var("e");
+
+        // Build rule: (a * b) + (c / d) - e
+        let rule = (var_a * var_b) + (var_c / var_d) - var_e;
+
+        // Serialize to JSON Logic
+        let json_logic =
+            serde_json::to_value(rule).expect("Failed to serialize the rule into JSON.");
+
+        // Define the expected JSON Logic
+        let expected_json = json!({
+            "-": [
+                { "+": [
+                    { "*": [ { "var": "a" }, { "var": "b" } ] },
+                    { "/": [ { "var": "c" }, { "var": "d" } ] }
+                ] },
+                { "var": "e" }
+            ]
+        });
+
+        // Assert that the serialized JSON matches the expected JSON
+        assert_eq!(json_logic, expected_json);
+    }
+
+    /// Tests the use of custom operators in rule creation.
+    ///
+    /// Constructs a rule using a custom operator `"customOp"` with operands `input` and `42`.
+    #[test]
+    fn test_custom_operator() {
+        let var_input = RuleWithValidation::var("input");
+
+        // Build rule using a custom operator "customOp"
+        let custom_rule =
+            RuleWithValidation::custom("customOp", vec![var_input, RuleWithValidation::from(42)]);
+
+        let json_logic =
+            serde_json::to_value(custom_rule).expect("Failed to serialize the rule into JSON.");
+        let expected_json = json!({
+            "customOp": [
+                { "var": "input" },
+                42
+            ]
+        });
+
+        assert_eq!(json_logic, expected_json);
+    }
+
+    /// Tests the creation and serialization of a rule with multiple logical and arithmetic operations.
+    ///
+    /// Constructs a rule that checks if `(x + y) > 10 AND (z <= 5 OR w != 3)`.
+    #[test]
+    fn test_combined_logical_and_arithmetic_operations() {
+        let var_x = RuleWithValidation::var("x");
+        let var_y = RuleWithValidation::var("y");
+        let var_z = RuleWithValidation::var("z");
+        let var_w = RuleWithValidation::var("w");
+
+        let const_ten = RuleWithValidation::value(10);
+        let const_five = RuleWithValidation::value(5);
+        let const_three = RuleWithValidation::value(3);
+
+        let rule_sum = var_x + var_y; // x + y
+        let rule_gt = rule_sum.gt(const_ten).unwrap(); // (x + y) > 10
+        let rule_le = var_z.lte(const_five).unwrap(); // z <= 5
+        let rule_ne = var_w.ne(const_three).unwrap(); // w != 3
+        let rule_or = rule_le | rule_ne; // (z <= 5 OR w != 3)
+        let combined_rule = rule_gt & rule_or; // (x + y) > 10 AND (z <= 5 OR w != 3)
+
+        // Serialize to JSON Logic
+        let json_logic =
+            serde_json::to_value(combined_rule).expect("Failed to serialize the rule into JSON.");
+
+        // Define the expected JSON Logic
+        let expected_json = json!({
+            "and": [
+                {
+                    ">": [
+                        { "+": [ { "var": "x" }, { "var": "y" } ] },
+                        10
+                    ]
+                },
+                {
+                    "or": [
+                        { "<=": [ { "var": "z" }, 5 ] },
+                        { "!=": [ { "var": "w" }, 3 ] }
+                    ]
+                }
+            ]
+        });
+
+        // Assert that the serialized JSON matches the expected JSON
+        assert_eq!(json_logic, expected_json);
+    }
+
+    #[test]
+    fn test_complex_rule_with_not_and_operator_overloading() {
+        let var_status = RuleWithValidation::var("status");
+        let var_attempts = RuleWithValidation::var("attempts");
+
+        let const_locked = RuleWithValidation::from("locked");
+        let const_max_attempts = RuleWithValidation::from(3);
+
+        // Build rule: !(status == "locked" || attempts > 3)
+        let rule =
+            !(var_status.eq(const_locked).unwrap() | var_attempts.gt(const_max_attempts).unwrap());
+
+        // Serialize to JSON Logic
+        let json_logic =
+            serde_json::to_value(rule).expect("Failed to serialize the rule into JSON.");
+
+        // Expected JSON Logic
+        let expected_json = json!({
+            "!": {
+                "or": [
+                    { "==": [ { "var": "status" }, "locked" ] },
+                    { ">": [ { "var": "attempts" }, 3 ] }
+                ]
+            }
+        });
+
+        assert_eq!(json_logic, expected_json);
+    }
+
+    /// Tests logical operations combined with operator overloading.
+    ///
+    /// Constructs a rule that checks if `a == 5` AND (`b > 10` OR `c < 20`).
+    #[test]
+    fn test_logical_operations() {
+        let var_a = RuleWithValidation::var("a");
+        let var_b = RuleWithValidation::var("b");
+        let var_c = RuleWithValidation::var("c");
+
+        let rule1 = var_a.eq(RuleWithValidation::from(5)).unwrap();
+        let rule2 = var_b.gt(RuleWithValidation::from(10)).unwrap();
+        let rule3 = var_c.lt(RuleWithValidation::from(20)).unwrap();
+
+        // Combine rules using logical operators
+        let combined_rule = rule1 & (rule2 | rule3);
+
+        // Serialize to JSON Logic
+        let json_logic =
+            serde_json::to_value(combined_rule).expect("Failed to serialize the rule into JSON.");
+
+        // Expected JSON Logic
+        let expected_json = json!({
+            "and": [
+                { "==": [ { "var": "a" }, 5 ] },
+                {
+                    "or": [
+                        { ">": [ { "var": "b" }, 10 ] },
+                        { "<": [ { "var": "c" }, 20 ] }
+                    ]
+                }
+            ]
+        });
+
+        assert_eq!(json_logic, expected_json);
+    }
+
+    /// Tests the creation and serialization of a complex rule using the desired API.
+    ///
+    /// The rule constructed is:
+    /// ```
+    /// view == 'recents.view.id' && viewItem == 'recents.item'
+    /// ```
+    ///
+    /// # Assertions
+    ///
+    /// - Verifies that the serialized JSON Logic matches the expected structure.
+    #[test]
+    fn test_rule_with_desired_api() {
+        let rule = RuleWithValidation::var("view")
+            .eq(RuleWithValidation::value("recents.view.id"))
+            .unwrap()
+            .and(
+                RuleWithValidation::var("viewItem")
+                    .eq(RuleWithValidation::value("recents.item"))
+                    .unwrap(),
+            )
+            .unwrap();
+
+        let json_logic =
+            serde_json::to_value(rule).expect("Failed to serialize the rule into JSON.");
+
+        let expected_json = json!({
+            "and": [
+                {
+                    "==": [
+                        { "var": "view" },
+                        "recents.view.id"
+                    ]
+                },
+                {
+                    "==": [
+                        { "var": "viewItem" },
+                        "recents.item"
+                    ]
+                }
+            ]
+        });
+
+        assert_eq!(json_logic, expected_json);
+    }
+
+    /// Tests the use of operator overloading (`&`, `|`, `+`, `-`, `*`, `/`, `!`) in rule creation.
+    ///
+    /// This test covers logical AND, OR, NOT operations, as well as arithmetic operations.
+    #[test]
+    fn test_operator_overloading() {
+        // Logical AND
+        let rule_and = RuleWithValidation::var("is_admin") & RuleWithValidation::var("is_active");
+        let expected_and = json!({
+            "and": [
+                { "var": "is_admin" },
+                { "var": "is_active" }
+            ]
+        });
+        assert_eq!(
+            serde_json::to_value(rule_and).expect("Failed to serialize the rule into JSON."),
+            expected_and
+        );
+
+        // Logical OR
+        let rule_or = RuleWithValidation::var("is_guest") | RuleWithValidation::var("is_banned");
+        let expected_or = json!({
+            "or": [
+                { "var": "is_guest" },
+                { "var": "is_banned" }
+            ]
+        });
+        assert_eq!(
+            serde_json::to_value(rule_or).expect("Failed to serialize the rule into JSON."),
+            expected_or
+        );
+
+        // Logical NOT
+        let rule_not = !RuleWithValidation::var("is_active");
+        let expected_not = json!({
+            "!": {
+                "var": "is_active"
+            }
+        });
+        assert_eq!(
+            serde_json::to_value(rule_not).expect("Failed to serialize the rule into JSON."),
+            expected_not
+        );
+
+        // Addition
+        let rule_add = RuleWithValidation::var("quantity") + RuleWithValidation::value(10);
+        let expected_add = json!({
+            "+": [
+                { "var": "quantity" },
+                10
+            ]
+        });
+        assert_eq!(
+            serde_json::to_value(rule_add).expect("Failed to serialize the rule into JSON."),
+            expected_add
+        );
+
+        // Subtraction
+        let rule_sub = RuleWithValidation::var("total") - RuleWithValidation::value(20);
+        let expected_sub = json!({
+            "-": [
+                { "var": "total" },
+                20
+            ]
+        });
+        assert_eq!(
+            serde_json::to_value(rule_sub).expect("Failed to serialize the rule into JSON."),
+            expected_sub
+        );
+
+        // Multiplication
+        let rule_mul = RuleWithValidation::var("price") * RuleWithValidation::value(2);
+        let expected_mul = json!({
+            "*": [
+                { "var": "price" },
+                2
+            ]
+        });
+        assert_eq!(
+            serde_json::to_value(rule_mul).expect("Failed to serialize the rule into JSON."),
+            expected_mul
+        );
+
+        // Division
+        let rule_div = RuleWithValidation::var("total") / RuleWithValidation::value(4);
+        let expected_div = json!({
+            "/": [
+                { "var": "total" },
+                4
+            ]
+        });
+        assert_eq!(
+            serde_json::to_value(rule_div).expect("Failed to serialize the rule into JSON."),
+            expected_div
+        );
+    }
+
+    /// Tests method chaining capabilities in rule creation.
+    ///
+    /// Constructs a rule that checks if `age >= 18` and `status == 'active'`.
+    #[test]
+    fn test_method_chaining() {
+        let rule = RuleWithValidation::var("age")
+            .gte(RuleWithValidation::value(18))
+            .unwrap()
+            .and(
+                RuleWithValidation::var("status")
+                    .eq(RuleWithValidation::value("active"))
+                    .unwrap(),
+            )
+            .unwrap();
+
+        let json_logic =
+            serde_json::to_value(rule).expect("Failed to serialize the rule into JSON.");
+
+        let expected_json = json!({
+            "and": [
+                {
+                    ">=": [
+                        { "var": "age" },
+                        18
+                    ]
+                },
+                {
+                    "==": [
+                        { "var": "status" },
+                        "active"
+                    ]
+                }
+            ]
+        });
+
+        assert_eq!(json_logic, expected_json);
+    }
+
+    #[test]
+    fn test_rule_with_variables_and_values() {
+        let rule = RuleWithValidation::var("status")
+            .ne(RuleWithValidation::value("inactive"))
+            .unwrap()
+            .and(
+                RuleWithValidation::var("age")
+                    .gte(RuleWithValidation::value(18))
+                    .unwrap(),
+            )
+            .unwrap();
+
+        let json_logic =
+            serde_json::to_value(rule).expect("Failed to serialize the rule into JSON.");
+
+        let expected_json = json!({
+            "and": [
+                {
+                    "!=": [
+                        { "var": "status" },
+                        "inactive"
+                    ]
+                },
+                {
+                    ">=": [
+                        { "var": "age" },
+                        18
+                    ]
+                }
+            ]
+        });
+
+        assert_eq!(json_logic, expected_json);
+    }
+
+    #[test]
+    fn test_rule_macro_simple_unary() {
+        let rule = rule_with_validation!(!flag);
+        assert_eq!(
+            serde_json::to_value(rule).expect("Failed to serialize the rule into JSON"),
+            json!({"!": {"var": "flag"}})
+        );
+    }
+
+    #[test]
+    fn test_rule_macro_simple_binary() {
+        let rule = rule_with_validation!(age > 18);
+        assert_eq!(
+            serde_json::to_value(rule).expect("Failed to serialize the rule into JSON."),
+            json!({ ">": [{ "var": "age" }, 18] })
+        );
+    }
+
+    #[test]
+    fn test_rule_macro_simple_variadic() {
+        let rule = rule_with_validation!(a + b + c);
+        println!("{}", serde_json::to_string_pretty(&rule).unwrap());
+        assert_eq!(
+            serde_json::to_value(rule).expect("Failed to serialize the rule into JSON"),
+            json!({"+" : [{"var" : "a"}, {"var" : "b"}, {"var" : "c"}]})
+        )
+    }
+
+    #[test]
+    fn test_rule_macro_logical_and() {
+        let rule = rule_with_validation!(age > 18 && status == "active");
+        assert_eq!(
+            serde_json::to_value(rule).expect("Failed to serialize the rule into JSON."),
+            json!({
+                "and": [
+                    { ">": [{ "var": "age" }, 18] },
+                    { "==": [{ "var": "status" }, "active"] }
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn test_rule_macro_complex() {
+        let rule = rule_with_validation!((age > 18 && status == "active") || is_admin);
+        assert_eq!(
+            serde_json::to_value(rule).expect("Failed to serialize the rule into JSON."),
+            json!({
+                "or": [
+                    {
+                        "and": [
+                            { ">": [{ "var": "age" }, 18] },
+                            { "==": [{ "var": "status" }, "active"] }
+                        ]
+                    },
+                    { "var": "is_admin" }
+                ]
+            })
+        );
+    }
+
+    #[test]
+    fn test_rule_macro_modulo() {
+        let rule = rule_with_validation!(number % 2 == 0);
+        assert_eq!(
+            serde_json::to_value(rule).expect("Failed to serialize the rule into JSON."),
+            json!({
+                "==": [
+                    {
+                        "%": [{ "var": "number" }, 2]
+                    },
+                    0
+                ]
+            })
+        );
+    }
+
+    // ----------------------------------------------------------------------------
+    // Validation Tests
+    // ----------------------------------------------------------------------------
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_type_not() {
+        let rule = rule_with_validation!(!"1");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_type_and() {
+        let rule = rule_with_validation!(1 && true);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_type_or() {
+        let rule = rule_with_validation!("1" || true);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_incompatible_type_eq() {
+        let rule = rule_with_validation!(1 == "1");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_incompatible_type_ne() {
+        let rule = rule_with_validation!(true != "false");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_type_gt() {
+        let rule = rule_with_validation!("42" > 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_type_lt() {
+        let rule = rule_with_validation!(false < true);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_type_gte() {
+        let rule = rule_with_validation!("42" >= 42);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_type_lte() {
+        let rule = rule_with_validation!(42 <= "42");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_type_add() {
+        let rule = rule_with_validation!(true + "true");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_type_subtract() {
+        let rule = rule_with_validation!("1" - 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_type_multiply() {
+        let rule = rule_with_validation!("1" * 2);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_type_divide() {
+        let rule = rule_with_validation!("foo" / "bar");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_type_modulo() {
+        let rule = rule_with_validation!("3" % "2");
+    }
+    #[test]
+    #[should_panic]
+    fn test_zero_division_divide() {
+        let rule = rule_with_validation!(42 / 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_zero_division_modulo() {
+        let rule = rule_with_validation!(42 % 0.0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_type_compound1() {
+        let rule = rule_with_validation!(1 + 2 / "3");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_type_compound2() {
+        let rule = rule_with_validation!(x - true * false);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_type_compound3() {
+        let rule = rule_with_validation!(x && !"true");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_type_compound4() {
+        let rule = rule_with_validation!(42 > 0 < 1);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_invalid_type_compound5() {
+        let rule = rule_with_validation!(3.14 < 159 - "26");
+    }
+}

--- a/crates/moss-jsonlogic/src/rule_with_validation.rs
+++ b/crates/moss-jsonlogic/src/rule_with_validation.rs
@@ -70,18 +70,18 @@ impl RuleType for Operator {
 }
 
 pub struct RuleWithValidation {
-    rule: Rule,
+    raw_rule: Rule,
 }
 
 impl From<Rule> for RuleWithValidation {
-    fn from(rule: Rule) -> Self {
-        RuleWithValidation { rule }
+    fn from(raw_rule: Rule) -> Self {
+        RuleWithValidation { raw_rule }
     }
 }
 
 impl RuleType for RuleWithValidation {
     fn get_type(&self) -> ResultType {
-        match &self.rule {
+        match &self.raw_rule {
             Rule::Constant(value) => match value {
                 Value::Null => ResultType::Undefined,
                 Value::Bool(_) => ResultType::Boolean,
@@ -133,7 +133,7 @@ impl RuleWithValidation {
         } else {
             Err(RuleError::InvalidType {
                 operator,
-                operand: invalid_operands[0].rule.clone(),
+                operand: invalid_operands[0].raw_rule.clone(),
             })
         }
     }
@@ -144,8 +144,8 @@ impl RuleWithValidation {
     ) -> Result<(), RuleError> {
         if !left.is_type_compatible_with(right) {
             return Err(RuleError::IncompatibleType {
-                left: left.rule.clone(),
-                right: right.rule.clone(),
+                left: left.raw_rule.clone(),
+                right: right.raw_rule.clone(),
             });
         }
         Ok(())
@@ -164,7 +164,7 @@ impl RuleWithValidation {
         } else {
             Err(RuleError::InvalidType {
                 operator,
-                operand: invalid_operands[0].rule.clone(),
+                operand: invalid_operands[0].raw_rule.clone(),
             })
         }
     }
@@ -175,11 +175,11 @@ impl RuleWithValidation {
     ) -> Result<(), RuleError> {
         // For now we only check zero literal
         // In the future, we can check expressions that evaluate to zero
-        if let Rule::Constant(divisor) = right.rule.clone() {
+        if let Rule::Constant(divisor) = right.raw_rule.clone() {
             if !divisor.is_number() {
                 return Err(RuleError::InvalidType {
                     operator,
-                    operand: right.rule.clone(),
+                    operand: right.raw_rule.clone(),
                 });
             }
             let divisor = divisor.as_number().unwrap();
@@ -210,80 +210,80 @@ impl RuleWithValidation {
     pub fn custom<S: Into<String>>(operator: S, operands: Vec<Self>) -> Self {
         Rule::Custom {
             operator: operator.into(),
-            operands: operands.into_iter().map(|x| x.rule).collect(),
+            operands: operands.into_iter().map(|x| x.raw_rule).collect(),
         }
         .into()
     }
 
     pub fn not(self) -> Result<Self, RuleError> {
         Self::validate_boolean_operators(Operator::Not, vec![&self])?;
-        Ok(self.rule.not().into())
+        Ok(self.raw_rule.not().into())
     }
 
     pub fn and(self, other: Self) -> Result<Self, RuleError> {
         Self::validate_boolean_operators(Operator::And, vec![&self, &other])?;
-        Ok(self.rule.and(other.rule).into())
+        Ok(self.raw_rule.and(other.raw_rule).into())
     }
 
     pub fn or(self, other: Self) -> Result<Self, RuleError> {
         Self::validate_boolean_operators(Operator::Or, vec![&self, &other])?;
-        Ok(self.rule.or(other.rule).into())
+        Ok(self.raw_rule.or(other.raw_rule).into())
     }
 
     pub fn eq(self, other: Self) -> Result<Self, RuleError> {
         Self::validate_equality_operators(&self, &other)?;
-        Ok(self.rule.eq(other.rule).into())
+        Ok(self.raw_rule.eq(other.raw_rule).into())
     }
 
     pub fn ne(self, other: Self) -> Result<Self, RuleError> {
         Self::validate_equality_operators(&self, &other)?;
-        Ok(self.rule.ne(other.rule).into())
+        Ok(self.raw_rule.ne(other.raw_rule).into())
     }
 
     pub fn gt(self, other: Self) -> Result<Self, RuleError> {
         Self::validate_numeric_operators(Operator::GreaterThan, vec![&self, &other])?;
-        Ok(self.rule.gt(other.rule).into())
+        Ok(self.raw_rule.gt(other.raw_rule).into())
     }
 
     pub fn lt(self, other: Self) -> Result<Self, RuleError> {
         Self::validate_numeric_operators(Operator::LessThan, vec![&self, &other])?;
-        Ok(self.rule.lt(other.rule).into())
+        Ok(self.raw_rule.lt(other.raw_rule).into())
     }
 
     pub fn gte(self, other: Self) -> Result<Self, RuleError> {
         Self::validate_numeric_operators(Operator::GreaterThanOrEqual, vec![&self, &other])?;
-        Ok(self.rule.gte(other.rule).into())
+        Ok(self.raw_rule.gte(other.raw_rule).into())
     }
 
     pub fn lte(self, other: Self) -> Result<Self, RuleError> {
         Self::validate_numeric_operators(Operator::LessThanOrEqual, vec![&self, &other])?;
-        Ok(self.rule.lte(other.rule).into())
+        Ok(self.raw_rule.lte(other.raw_rule).into())
     }
 
     pub fn add(self, other: Self) -> Result<Self, RuleError> {
         Self::validate_numeric_operators(Operator::Add, vec![&self, &other])?;
-        Ok(self.rule.add(other.rule).into())
+        Ok(self.raw_rule.add(other.raw_rule).into())
     }
 
     pub fn subtract(self, other: Self) -> Result<Self, RuleError> {
         Self::validate_numeric_operators(Operator::Subtract, vec![&self, &other])?;
-        Ok(self.rule.subtract(other.rule).into())
+        Ok(self.raw_rule.subtract(other.raw_rule).into())
     }
 
     pub fn multiply(self, other: Self) -> Result<Self, RuleError> {
         Self::validate_numeric_operators(Operator::Multiply, vec![&self, &other])?;
-        Ok(self.rule.multiply(other.rule).into())
+        Ok(self.raw_rule.multiply(other.raw_rule).into())
     }
     pub fn divide(self, other: Self) -> Result<Self, RuleError> {
         Self::validate_numeric_operators(Operator::Divide, vec![&self, &other])?;
         Self::validate_division(Operator::Divide, &other)?;
-        Ok(self.rule.divide(other.rule).into())
+        Ok(self.raw_rule.divide(other.raw_rule).into())
     }
 
     pub fn modulo(self, other: Self) -> Result<Self, RuleError> {
         Self::validate_numeric_operators(Operator::Modulo, vec![&self, &other])?;
         Self::validate_division(Operator::Modulo, &other)?;
-        Ok(self.rule.modulo(other.rule).into())
+        Ok(self.raw_rule.modulo(other.raw_rule).into())
     }
 }
 
@@ -292,7 +292,7 @@ impl Serialize for RuleWithValidation {
     where
         S: Serializer,
     {
-        self.rule.serialize(serializer)
+        self.raw_rule.serialize(serializer)
     }
 }
 

--- a/crates/moss-jsonlogic/src/rule_with_validation.rs
+++ b/crates/moss-jsonlogic/src/rule_with_validation.rs
@@ -100,9 +100,6 @@ impl RuleType for RuleWithValidation {
 }
 
 impl RuleWithValidation {
-    // ----------------------------------------------------------------------------
-    // Role Methods
-    // ----------------------------------------------------------------------------
     fn is_type_compatible_with(&self, other: &RuleWithValidation) -> bool {
         let self_type = self.get_type();
         let other_type = other.get_type();
@@ -123,9 +120,6 @@ impl RuleWithValidation {
         self.get_type() == ResultType::Number || self.get_type() == ResultType::Variable
     }
 
-    // ----------------------------------------------------------------------------
-    // Validation Methods
-    // ----------------------------------------------------------------------------
     pub fn validate_boolean_operators(
         operator: Operator,
         operands: Vec<&RuleWithValidation>,
@@ -200,9 +194,7 @@ impl RuleWithValidation {
             Ok(())
         }
     }
-    // ----------------------------------------------------------------------------
-    // Constructor Methods
-    // ----------------------------------------------------------------------------
+
     pub fn value<V: Into<Value>>(value: V) -> Self {
         Rule::Constant(value.into()).into()
     }
@@ -222,10 +214,6 @@ impl RuleWithValidation {
         }
         .into()
     }
-
-    // ----------------------------------------------------------------------------
-    // Operator-Specific Methods
-    // ----------------------------------------------------------------------------
 
     pub fn not(self) -> Result<Self, RuleError> {
         Self::validate_boolean_operators(Operator::Not, vec![&self])?;
@@ -403,11 +391,6 @@ mod tests {
     use moss_jsonlogic_macro::rule_with_validation;
     use serde_json::json;
 
-    /// ----------------------------------------------------------------------------
-    /// Basic Tests
-    ///
-    /// Ensure that `RuleWithValidation` has consistent behaviors with `Rule`
-    /// ----------------------------------------------------------------------------
     #[test]
     fn test_arithmetic_operations() {
         let var_x = RuleWithValidation::var("x");
@@ -521,9 +504,6 @@ mod tests {
         assert_eq!(json_logic, expected_json);
     }
 
-    /// Tests the combination of logical and arithmetic operations with operator overloading.
-    ///
-    /// Constructs a rule that checks if `(x * y) + z <= 100`.
     #[test]
     fn test_combining_logical_and_arithmetic_operations() {
         let var_score = RuleWithValidation::var("score");
@@ -549,9 +529,6 @@ mod tests {
         assert_eq!(json_logic, expected_json);
     }
 
-    /// Tests complex nested rules involving logical NOT and operator overloading.
-    ///
-    /// Constructs a rule that represents `!(status == "locked" || attempts > 3)`.
     #[test]
     fn test_complex_nested_rules_with_not() {
         let var_status = RuleWithValidation::var("status");
@@ -581,9 +558,6 @@ mod tests {
         assert_eq!(json_logic, expected_json);
     }
 
-    /// Tests serialization of rules with multiple arithmetic operations.
-    ///
-    /// Constructs a rule that represents `(a * b) + (c / d) - e`.
     #[test]
     fn test_multiple_arithmetic_operations() {
         let var_a = RuleWithValidation::var("a");
@@ -614,9 +588,6 @@ mod tests {
         assert_eq!(json_logic, expected_json);
     }
 
-    /// Tests the use of custom operators in rule creation.
-    ///
-    /// Constructs a rule using a custom operator `"customOp"` with operands `input` and `42`.
     #[test]
     fn test_custom_operator() {
         let var_input = RuleWithValidation::var("input");
@@ -637,9 +608,6 @@ mod tests {
         assert_eq!(json_logic, expected_json);
     }
 
-    /// Tests the creation and serialization of a rule with multiple logical and arithmetic operations.
-    ///
-    /// Constructs a rule that checks if `(x + y) > 10 AND (z <= 5 OR w != 3)`.
     #[test]
     fn test_combined_logical_and_arithmetic_operations() {
         let var_x = RuleWithValidation::var("x");
@@ -713,9 +681,6 @@ mod tests {
         assert_eq!(json_logic, expected_json);
     }
 
-    /// Tests logical operations combined with operator overloading.
-    ///
-    /// Constructs a rule that checks if `a == 5` AND (`b > 10` OR `c < 20`).
     #[test]
     fn test_logical_operations() {
         let var_a = RuleWithValidation::var("a");
@@ -749,16 +714,6 @@ mod tests {
         assert_eq!(json_logic, expected_json);
     }
 
-    /// Tests the creation and serialization of a complex rule using the desired API.
-    ///
-    /// The rule constructed is:
-    /// ```
-    /// view == 'recents.view.id' && viewItem == 'recents.item'
-    /// ```
-    ///
-    /// # Assertions
-    ///
-    /// - Verifies that the serialized JSON Logic matches the expected structure.
     #[test]
     fn test_rule_with_desired_api() {
         let rule = RuleWithValidation::var("view")
@@ -794,9 +749,6 @@ mod tests {
         assert_eq!(json_logic, expected_json);
     }
 
-    /// Tests the use of operator overloading (`&`, `|`, `+`, `-`, `*`, `/`, `!`) in rule creation.
-    ///
-    /// This test covers logical AND, OR, NOT operations, as well as arithmetic operations.
     #[test]
     fn test_operator_overloading() {
         // Logical AND
@@ -890,9 +842,6 @@ mod tests {
         );
     }
 
-    /// Tests method chaining capabilities in rule creation.
-    ///
-    /// Constructs a rule that checks if `age >= 18` and `status == 'active'`.
     #[test]
     fn test_method_chaining() {
         let rule = RuleWithValidation::var("age")
@@ -1039,10 +988,6 @@ mod tests {
             })
         );
     }
-
-    // ----------------------------------------------------------------------------
-    // Validation Tests
-    // ----------------------------------------------------------------------------
 
     #[test]
     #[should_panic]


### PR DESCRIPTION
Implement a type-based JSON logic validation mechanism by creating a new wrapper type `RuleWithValidation` that wraps around a raw `Rule`. `Rule` will behave like before with no validation logic, while `RuleWithValidation` will validate the operation, and return a `RuleError` if the validation fails. `rule_with_validation!` macro will panic with the corresponding error on failed validation.

1. Each `RuleWithValidation` is associated with one type, which roughly matches the types of serde::Value. If the rule is a constant, it will use the type of its content; If it's a variable, then its type would be variable; otherwise, the operator's result type determines its type.
2. When creating new `RuleWithValidation` by composing rules with operators, we will check if the operands' type satisfy the operators' constraints. For example, arithmetic operators require operands to be numeric, while equality operators require both sides to have the same time. For now, variable type is considered compatible with all other types.
3. Define three basic errors that can happen during the validation.
