### PR TITLE
chore(MOSSMVP-299): Enhance the rust audit command

### DIFF
--- a/tools/xtask/config.toml
+++ b/tools/xtask/config.toml
@@ -1,12 +1,22 @@
 licenses = ["LICENSE-MIT"]
 
-[rust_workspace_audit.ignore]
+# Global
+rust_workspace_audit.global_ignore = [
+    "syn",
+    "quote",
+    "proc-macro2",
+    "tauri-plugin-cli",
+    "clap"
+]
+
+[rust_workspace_audit.crate_ignore]
 desktop = [
     "tauri-plugin-shell",
     "tauri-plugin-os",
     "tauri-specta",
     "tauri-plugin-fs",
     "tauri-plugin-log",
+    "tauri-plugin-global-shortcut",
     "tauri-plugin-clipboard-manager",
     "tauri-plugin-window-state"
 ]

--- a/tools/xtask/config.toml
+++ b/tools/xtask/config.toml
@@ -5,7 +5,6 @@ rust_workspace_audit.global_ignore = [
     "syn",
     "quote",
     "proc-macro2",
-    "tauri-plugin-cli",
     "clap"
 ]
 
@@ -18,7 +17,8 @@ desktop = [
     "tauri-plugin-log",
     "tauri-plugin-global-shortcut",
     "tauri-plugin-clipboard-manager",
-    "tauri-plugin-window-state"
+    "tauri-plugin-window-state",
+    "tauri-plugin-cli",
 ]
 
 xtask = [

--- a/tools/xtask/src/config.rs
+++ b/tools/xtask/src/config.rs
@@ -8,12 +8,13 @@ use std::path::Path;
 #[derive(Deserialize, Default)]
 pub struct ConfigFile {
     pub licenses: Vec<String>,
-    pub rust_workspace_audit: RustWorkspaceAuditBlock,
+    pub rust_workspace_audit: RustWorkspaceAuditConfig,
 }
 
 #[derive(Deserialize, Default)]
-pub struct RustWorkspaceAuditBlock {
-    pub ignore: HashMap<String, Vec<String>>,
+pub struct RustWorkspaceAuditConfig {
+    pub global_ignore: Vec<String>,
+    pub crate_ignore: HashMap<String, Vec<String>>,
 }
 
 impl ConfigFile {

--- a/tools/xtask/src/tasks/rust_workspace_audit.rs
+++ b/tools/xtask/src/tasks/rust_workspace_audit.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 use futures::future::join_all;
 use smol::fs;
 use std::{io, sync::Arc};
+use tokio::task::JoinSet;
 use toml::Value;
 use tracing::{error, info, trace, warn};
 
@@ -18,16 +19,19 @@ pub struct RustWorkspaceAuditCommandArgs {
 pub async fn check_dependencies_job(
     args: RustWorkspaceAuditCommandArgs,
     metadata: Metadata,
+    fail_fast: bool,
 ) -> Result<()> {
+    let mut task_set = JoinSet::new();
+
     let config_file = Arc::new(ConfigFile::load(&args.config_file_path).await?);
-    let tasks = metadata
+    metadata
         .packages
         .into_iter()
         .filter(|p| metadata.workspace_members.contains(&p.id))
-        .map(|package| {
+        .for_each(|package| {
             let config_file_clone = Arc::clone(&config_file);
 
-            tokio::task::spawn(async move {
+            task_set.spawn(async move {
                 trace!("analyzing '{}'...", package.name);
                 let cargo_toml_content = match fs::read_to_string(&package.manifest_path).await {
                     Ok(content) => content,
@@ -51,20 +55,40 @@ pub async fn check_dependencies_job(
                     }
                 };
 
-                handle_package_dependencies(cargo_toml, &config_file_clone, package).await;
+                match handle_package_dependencies(cargo_toml, &config_file_clone, package).await {
+                    Ok(()) => Ok(()),
+                    Err(e) => Err(e),
+                }
+            });
+        });
 
-                Ok(())
-            })
-        })
-        .collect::<Vec<_>>();
-
-    for result in join_all(tasks).await {
+    while let Some(result) = task_set.join_next().await {
         match result {
             Ok(Ok(())) => {}
-            Ok(Err(e)) => error!("Error processing package: {}", e),
-            Err(e) => error!("Task panicked: {}", e),
+            Ok(Err(e)) => {
+                if fail_fast {
+                    task_set.abort_all();
+                    return Err(anyhow!(e));
+                }
+                error!("Error when processing package: {}", e)
+            }
+            Err(e) => {
+                if fail_fast {
+                    task_set.abort_all();
+                    return Err(anyhow!("Task panicked: {}", e));
+                }
+                error!("Task panicked: {}", e)
+            }
         }
     }
+
+    // for result in join_all(tasks).await {
+    //     match result {
+    //         Ok(Ok(())) => {}
+    //         Ok(Err(e)) => error!("Error processing package: {}", e),
+    //         Err(e) => error!("Task panicked: {}", e),
+    //     }
+    // }
 
     Ok(())
 }
@@ -73,7 +97,7 @@ async fn handle_package_dependencies(
     cargo_toml: Value,
     ignored_deps: &ConfigFile,
     package: Package,
-) {
+) -> Result<()> {
     if let Some(dependencies) = cargo_toml.get("dependencies").and_then(|d| d.as_table()) {
         for (dep_name, dep_value) in dependencies {
             if let Some(ignored_list) = ignored_deps.rust_workspace_audit.ignore.get(&package.name)
@@ -95,7 +119,13 @@ async fn handle_package_dependencies(
                     "crate '{}' has non-workspace dependency: {}",
                     package.name, dep_name
                 );
+                return Err(anyhow!(
+                    "crate '{}' has non-workspace dependency: {}",
+                    package.name,
+                    dep_name
+                ));
             }
         }
     }
+    Ok(())
 }


### PR DESCRIPTION
1. Add a new flag `--fail-fast` to `xtask rwa` so that the program will terminate as soon as one rule violation is encountered.
2. Add a config section to specify dependencies that should be ignored from workspace dependency checks across the board.