### PR TITLE
chore(MOSSMVP-292): Add frontend tests to the CI

### DIFF
--- a/.github/cache/dummy.txt
+++ b/.github/cache/dummy.txt
@@ -1,1 +1,0 @@
-This folder will hold cache for GitHub Actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           cd ${GITHUB_WORKSPACE}/tools/xtask 
           cargo -q run -- --fail-fast rwa
 
-  vitest:
+  vitest-packages:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -62,4 +62,24 @@ jobs:
         run: pnpm install
 
       - name: Run vitest
-        run: pnpm test
+        run: pnpm vitest --project packages
+
+  vitest-desktop:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: "package.json"
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run vitest
+        run: pnpm vitest --project desktop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,3 +43,23 @@ jobs:
         run: |
           cd ${GITHUB_WORKSPACE}/tools/xtask 
           cargo -q run -- --fail-fast rwa
+
+  vitest:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: "package.json"
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run vitest
+        run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
         run: pnpm install
 
       - name: Run vitest
-        run: pnpm vitest --project packages
+        run: pnpm run test --project packages
 
   vitest-desktop:
     runs-on: ubuntu-latest
@@ -82,4 +82,4 @@ jobs:
         run: pnpm install
 
       - name: Run vitest
-        run: pnpm vitest --project desktop
+        run: pnpm run test --project desktop

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  test:
-    name: Test suite
+  rust-test-suite:
+    name: Rust Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -30,21 +30,24 @@ jobs:
         run: cargo -q test --lib
         working-directory: ".github/cache"
 
-      - name: Run Doc Tests
+      - name: Run Documentation Tests
         if: always()
         run: cargo -q test --doc
         working-directory: ".github/cache"
-  audit:
+
+  rust-dependency-audit:
+    name: Rust Dependency Audit
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
-      - name: Rust Workspace Dependencies Audit
+      - name: Audit Rust Workspace Dependencies
         run: |
           cd ${GITHUB_WORKSPACE}/tools/xtask 
           cargo -q run -- --fail-fast rwa
 
-  vitest-packages:
+  vitest-package-tests:
+    name: Vitest Package Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -56,15 +59,16 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: "package.json"
-          cache: 'pnpm'
+          cache: "pnpm"
 
-      - name: Install dependencies
+      - name: Install Dependencies
         run: pnpm install
 
-      - name: Run vitest
+      - name: Run Vitest for Packages
         run: pnpm run test --project packages
 
-  vitest-desktop:
+  vitest-desktop-tests:
+    name: Vitest Desktop Tests
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -76,10 +80,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version-file: "package.json"
-          cache: 'pnpm'
+          cache: "pnpm"
 
-      - name: Install dependencies
+      - name: Install Dependencies
         run: pnpm install
 
-      - name: Run vitest
+      - name: Run Vitest for Desktop
         run: pnpm run test --project desktop

--- a/view/desktop/src/test.test.ts
+++ b/view/desktop/src/test.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from "vitest";
+
+//TODO remove this test when we have a test suite
+test("test test so github actions could pass", () => {
+  expect(1 + 2).toBe(3);
+});

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -1,3 +1,16 @@
 import { defineWorkspace } from "vitest/config";
 
-export default defineWorkspace(["packages/*", "view/*"]);
+export default defineWorkspace([
+  {
+    test: {
+      name: "packages",
+      include: ["packages/**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+    },
+  },
+  {
+    test: {
+      name: "desktop",
+      include: ["view/desktop/**/*.{test,spec}.?(c|m)[jt]s?(x)"],
+    },
+  },
+]);


### PR DESCRIPTION
Right now we are only running `vitest --globals`, since we only have a global eslint rule.