### PR TITLE
refactor(MOSSMVP-319): Improve themegen utility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,26 @@ install-themes:
 			 --output $(THEME_DIR); \
 	done
 
+
+## Windows does not support for loop in makefile, unfortunately
+.PHONY: install-themes-windows
+install-themes-windows:
+	$(CARGO) run --bin themeinstall -- \
+		 --schema ./@typespec/json-schema/Theme.json \
+		 --input $(THEME_DIR)/moss-dark.json \
+		 --output $(THEME_DIR) \
+
+	$(CARGO) run --bin themeinstall -- \
+		 --schema ./@typespec/json-schema/Theme.json \
+		 --input $(THEME_DIR)/moss-light.json \
+		 --output $(THEME_DIR) \
+
+	$(CARGO) run --bin themeinstall -- \
+		 --schema ./@typespec/json-schema/Theme.json \
+		 --input $(THEME_DIR)/moss-pink.json \
+		 --output $(THEME_DIR) \
+
+
 ## Compile Theme JSON Schema
 .PHONY: compile-themes-schema
 compile-themes-schema:

--- a/Makefile
+++ b/Makefile
@@ -109,22 +109,8 @@ gen-themes:
 ## Convert Theme JSONs to CSS
 .PHONY: install-themes
 install-themes:
-	@if [ ! -f $(THEME_INSTALLER_DIR)/target/debug/themeinstall ]; then \
-		echo "Building themeinstall binary..."; \
-		cd $(THEME_INSTALLER_DIR) && cargo build --bin themeinstall --target-dir ./target; \
-	fi
-
-	@for theme in moss-dark moss-light moss-pink; do \
-		$(THEME_INSTALLER_DIR)/target/debug/themeinstall \
-			 --schema ./@typespec/json-schema/Theme.json \
-			 --input $(THEME_DIR)/$$theme.json \
-			 --output $(THEME_DIR); \
-	done
-
-
+ifeq ($(DETECTED_OS),Windows)
 ## Windows does not support for loop in makefile, unfortunately
-.PHONY: install-themes-windows
-install-themes-windows:
 	$(CARGO) run --bin themeinstall -- \
 		 --schema ./@typespec/json-schema/Theme.json \
 		 --input $(THEME_DIR)/moss-dark.json \
@@ -139,6 +125,20 @@ install-themes-windows:
 		 --schema ./@typespec/json-schema/Theme.json \
 		 --input $(THEME_DIR)/moss-pink.json \
 		 --output $(THEME_DIR) \
+
+else
+	@if [ ! -f $(THEME_INSTALLER_DIR)/target/debug/themeinstall ]; then \
+		echo "Building themeinstall binary..."; \
+		cd $(THEME_INSTALLER_DIR) && cargo build --bin themeinstall --target-dir ./target; \
+	fi
+
+	@for theme in moss-dark moss-light moss-pink; do \
+		$(THEME_INSTALLER_DIR)/target/debug/themeinstall \
+			 --schema ./@typespec/json-schema/Theme.json \
+			 --input $(THEME_DIR)/$$theme.json \
+			 --output $(THEME_DIR); \
+	done
+endif
 
 
 ## Compile Theme JSON Schema

--- a/tools/themegen/src/color.ts
+++ b/tools/themegen/src/color.ts
@@ -1,0 +1,47 @@
+export type ColorStop = [color: string, percentage: number];
+
+export function clamp_rgb(value: number) {
+  if (value < 0) {
+    return 0;
+  } else if (value > 255) {
+    return 255;
+  } else {
+    return value;
+  }
+}
+
+export function clamp_alpha(value: number) {
+  if (value < 0) {
+    return 0;
+  } else if (value > 1) {
+    return 1;
+  } else {
+    return value;
+  }
+}
+
+export function clamp_percent(percent: number) {
+  if (percent < 0) {
+    return 0;
+  } else if (percent > 100) {
+    return 100;
+  } else {
+    return percent;
+  }
+}
+
+export function rgba(r: number, g: number, b: number, a: number) {
+  return `rgba(${clamp_rgb(r)}, ${clamp_rgb(g)}, ${clamp_rgb(b)}, ${clamp_alpha(a)})`;
+}
+
+export function linearGradient(direction: string, ...colorStopList: ColorStop[]) {
+  return (
+    `linear-gradient(${direction}` +
+    colorStopList
+      .map((stop) => {
+        return `, ${stop[0]} ${clamp_percent(stop[1])}%`;
+      })
+      .join("") +
+    ")"
+  );
+}

--- a/tools/themegen/src/index.ts
+++ b/tools/themegen/src/index.ts
@@ -7,6 +7,54 @@ import { Theme } from "@repo/desktop-models";
 const homeDirectory = os.homedir();
 const themesDirectory = `${homeDirectory}/.config/moss/themes`;
 
+type ColorStop = [color: string, percentage: number];
+
+function clamp_rgb(value: number) {
+  if (value < 0) {
+    return 0;
+  } else if (value > 255) {
+    return 255;
+  } else {
+    return value;
+  }
+}
+
+function clamp_alpha(value: number) {
+  if (value < 0) {
+    return 0;
+  } else if (value > 1) {
+    return 1;
+  } else {
+    return value;
+  }
+}
+
+function clamp_percent(percent: number) {
+  if (percent < 0) {
+    return 0;
+  } else if (percent > 100) {
+    return 100;
+  } else {
+    return percent;
+  }
+}
+
+function rgba(r: number, g: number, b: number, a: number) {
+  return `rgba(${clamp_rgb(r)}, ${clamp_rgb(g)}, ${clamp_rgb(b)}, ${clamp_alpha(a)})`;
+}
+
+function linearGradient(direction: string, ...colorStopList: ColorStop[]) {
+  return (
+    `linear-gradient(${direction}` +
+    colorStopList
+      .map((stop) => {
+        return `, ${stop[0]} ${clamp_percent(stop[1])}%`;
+      })
+      .join("") +
+    ")"
+  );
+}
+
 // Default
 const defaultDarkTheme: Theme = {
   name: "Moss Dark Default",
@@ -14,16 +62,16 @@ const defaultDarkTheme: Theme = {
   type: "dark",
   isDefault: false,
   colors: {
-    "primary": { "type": "solid", "value": "rgba(255, 255, 255, 1)" }, // prettier-ignore
-    "sideBar.background": { type: "solid", value: "rgba(39, 39, 42, 1)" },
-    "toolBar.background": { type: "solid", value: "rgba(30, 32, 33, 1)" },
-    "page.background": { type: "solid", value: "rgba(22, 24, 25, 1)" },
+    "primary": { "type": "solid", "value": rgba(255, 255, 255, 1) }, // prettier-ignore
+    "sideBar.background": { type: "solid", value: rgba(39, 39, 42, 1) },
+    "toolBar.background": { type: "solid", value: rgba(30, 32, 33, 1) },
+    "page.background": { type: "solid", value: rgba(22, 24, 25, 1) },
     "statusBar.background": { type: "solid", value: "#0F62FE" },
-    "windowsCloseButton.background": { type: "solid", value: "rgba(196, 43, 28, 1)" },
-    "windowControlsLinux.background": { type: "solid", value: "rgba(55, 55, 55, 1)" },
-    "windowControlsLinux.text": { type: "solid", value: "rgba(255, 255, 255, 1)" },
-    "windowControlsLinux.hoverBackground": { type: "solid", value: "rgba(66, 66, 66, 1)" },
-    "windowControlsLinux.activeBackground": { type: "solid", value: "rgba(86, 86, 86, 1)" },
+    "windowsCloseButton.background": { type: "solid", value: rgba(196, 43, 28, 1) },
+    "windowControlsLinux.background": { type: "solid", value: rgba(55, 55, 55, 1) },
+    "windowControlsLinux.text": { type: "solid", value: rgba(255, 255, 255, 1) },
+    "windowControlsLinux.hoverBackground": { type: "solid", value: rgba(66, 66, 66, 1) },
+    "windowControlsLinux.activeBackground": { type: "solid", value: rgba(86, 86, 86, 1) },
   },
 };
 
@@ -33,16 +81,16 @@ const defaultLightTheme: Theme = {
   type: "light",
   isDefault: true,
   colors: {
-    "primary": { "type": "solid", "value": "rgba(0, 0, 0, 1)" }, // prettier-ignore
-    "sideBar.background": { type: "solid", value: "rgba(244, 244, 245, 1)" },
-    "toolBar.background": { type: "solid", value: "rgba(224, 224, 224, 1)" },
-    "page.background": { type: "solid", value: "rgba(255, 255, 255, 1)" },
+    "primary": { "type": "solid", "value": rgba(0, 0, 0, 1) }, // prettier-ignore
+    "sideBar.background": { type: "solid", value: rgba(244, 244, 245, 1) },
+    "toolBar.background": { type: "solid", value: rgba(224, 224, 224, 1) },
+    "page.background": { type: "solid", value: rgba(255, 255, 255, 1) },
     "statusBar.background": { type: "solid", value: "#0F62FE" },
-    "windowsCloseButton.background": { type: "solid", value: "rgba(196, 43, 28, 1)" },
-    "windowControlsLinux.background": { type: "solid", value: "rgba(218, 218, 218, 1)" },
-    "windowControlsLinux.text": { type: "solid", value: "rgba(61, 61, 61, 1)" },
-    "windowControlsLinux.hoverBackground": { type: "solid", value: "rgba(209, 209, 209, 1)" },
-    "windowControlsLinux.activeBackground": { type: "solid", value: "rgba(191, 191, 191, 1)" },
+    "windowsCloseButton.background": { type: "solid", value: rgba(196, 43, 28, 1) },
+    "windowControlsLinux.background": { type: "solid", value: rgba(218, 218, 218, 1) },
+    "windowControlsLinux.text": { type: "solid", value: rgba(61, 61, 61, 1) },
+    "windowControlsLinux.hoverBackground": { type: "solid", value: rgba(209, 209, 209, 1) },
+    "windowControlsLinux.activeBackground": { type: "solid", value: rgba(191, 191, 191, 1) },
   },
 };
 
@@ -54,20 +102,26 @@ const pinkTheme: Theme = {
   type: "light",
   isDefault: false,
   colors: {
-    "primary": { "type": "solid", "value": "rgba(0, 0, 0, 1)" }, // prettier-ignore
-    "sideBar.background": { type: "solid", value: "rgba(234, 157, 242, 1)" },
-    "toolBar.background": { type: "solid", value: "rgba(222, 125, 232, 1)" },
-    "page.background": { type: "solid", value: "rgba(227, 54, 245, 1)" },
+    "primary": { "type": "solid", "value": rgba(0, 0, 0, 1) }, // prettier-ignore
+    "sideBar.background": { type: "solid", value: rgba(234, 157, 242, 1) },
+    "toolBar.background": { type: "solid", value: rgba(222, 125, 232, 1) },
+    "page.background": { type: "solid", value: rgba(227, 54, 245, 1) },
     "statusBar.background": {
       type: "gradient",
-      value:
-        "linear-gradient(90deg, rgba(255, 0, 0, 1) 0%, rgba(224, 0, 41, 1) 16%, rgba(190, 0, 87, 1) 34%, rgba(155, 0, 133, 1) 51%, rgba(63, 0, 255, 1) 100%)",
+      value: linearGradient(
+        "90deg",
+        [rgba(255, 0, 0, 1), 0],
+        [rgba(224, 0, 41, 1), 16],
+        [rgba(190, 0, 87, 1), 34],
+        [rgba(155, 0, 133, 1), 51],
+        [rgba(63, 0, 255, 1), 100]
+      ),
     },
-    "windowsCloseButton.background": { type: "solid", value: "rgba(196, 43, 28, 1)" },
-    "windowControlsLinux.background": { type: "solid", value: "rgba(218, 218, 218, 1)" },
-    "windowControlsLinux.text": { type: "solid", value: "rgba(61, 61, 61, 1)" },
-    "windowControlsLinux.hoverBackground": { type: "solid", value: "rgba(209, 209, 209, 1)" },
-    "windowControlsLinux.activeBackground": { type: "solid", value: "rgba(191, 191, 191, 1)" },
+    "windowsCloseButton.background": { type: "solid", value: rgba(196, 43, 28, 1) },
+    "windowControlsLinux.background": { type: "solid", value: rgba(218, 218, 218, 1) },
+    "windowControlsLinux.text": { type: "solid", value: rgba(61, 61, 61, 1) },
+    "windowControlsLinux.hoverBackground": { type: "solid", value: rgba(209, 209, 209, 1) },
+    "windowControlsLinux.activeBackground": { type: "solid", value: rgba(191, 191, 191, 1) },
   },
 };
 

--- a/tools/themegen/src/index.ts
+++ b/tools/themegen/src/index.ts
@@ -2,128 +2,13 @@ import { existsSync, mkdirSync, writeFileSync } from "fs";
 import * as os from "os";
 
 import { Theme } from "@repo/desktop-models";
+import { defaultDarkTheme } from "./themes/moss-dark.ts";
+import { defaultLightTheme } from "./themes/moss-light.ts";
+import { pinkTheme } from "./themes/moss-pink.ts";
 
 // FIXME: temporary solution. Also should be fixed in packages/config-eslint/moss-lint-plugin/rules/validate-token-names.js
 const homeDirectory = os.homedir();
 const themesDirectory = `${homeDirectory}/.config/moss/themes`;
-
-type ColorStop = [color: string, percentage: number];
-
-function clamp_rgb(value: number) {
-  if (value < 0) {
-    return 0;
-  } else if (value > 255) {
-    return 255;
-  } else {
-    return value;
-  }
-}
-
-function clamp_alpha(value: number) {
-  if (value < 0) {
-    return 0;
-  } else if (value > 1) {
-    return 1;
-  } else {
-    return value;
-  }
-}
-
-function clamp_percent(percent: number) {
-  if (percent < 0) {
-    return 0;
-  } else if (percent > 100) {
-    return 100;
-  } else {
-    return percent;
-  }
-}
-
-function rgba(r: number, g: number, b: number, a: number) {
-  return `rgba(${clamp_rgb(r)}, ${clamp_rgb(g)}, ${clamp_rgb(b)}, ${clamp_alpha(a)})`;
-}
-
-function linearGradient(direction: string, ...colorStopList: ColorStop[]) {
-  return (
-    `linear-gradient(${direction}` +
-    colorStopList
-      .map((stop) => {
-        return `, ${stop[0]} ${clamp_percent(stop[1])}%`;
-      })
-      .join("") +
-    ")"
-  );
-}
-
-// Default
-const defaultDarkTheme: Theme = {
-  name: "Moss Dark Default",
-  slug: "moss-dark",
-  type: "dark",
-  isDefault: false,
-  colors: {
-    "primary": { "type": "solid", "value": rgba(255, 255, 255, 1) }, // prettier-ignore
-    "sideBar.background": { type: "solid", value: rgba(39, 39, 42, 1) },
-    "toolBar.background": { type: "solid", value: rgba(30, 32, 33, 1) },
-    "page.background": { type: "solid", value: rgba(22, 24, 25, 1) },
-    "statusBar.background": { type: "solid", value: "#0F62FE" },
-    "windowsCloseButton.background": { type: "solid", value: rgba(196, 43, 28, 1) },
-    "windowControlsLinux.background": { type: "solid", value: rgba(55, 55, 55, 1) },
-    "windowControlsLinux.text": { type: "solid", value: rgba(255, 255, 255, 1) },
-    "windowControlsLinux.hoverBackground": { type: "solid", value: rgba(66, 66, 66, 1) },
-    "windowControlsLinux.activeBackground": { type: "solid", value: rgba(86, 86, 86, 1) },
-  },
-};
-
-const defaultLightTheme: Theme = {
-  name: "Moss Light Default",
-  slug: "moss-light",
-  type: "light",
-  isDefault: true,
-  colors: {
-    "primary": { "type": "solid", "value": rgba(0, 0, 0, 1) }, // prettier-ignore
-    "sideBar.background": { type: "solid", value: rgba(244, 244, 245, 1) },
-    "toolBar.background": { type: "solid", value: rgba(224, 224, 224, 1) },
-    "page.background": { type: "solid", value: rgba(255, 255, 255, 1) },
-    "statusBar.background": { type: "solid", value: "#0F62FE" },
-    "windowsCloseButton.background": { type: "solid", value: rgba(196, 43, 28, 1) },
-    "windowControlsLinux.background": { type: "solid", value: rgba(218, 218, 218, 1) },
-    "windowControlsLinux.text": { type: "solid", value: rgba(61, 61, 61, 1) },
-    "windowControlsLinux.hoverBackground": { type: "solid", value: rgba(209, 209, 209, 1) },
-    "windowControlsLinux.activeBackground": { type: "solid", value: rgba(191, 191, 191, 1) },
-  },
-};
-
-// Other
-
-const pinkTheme: Theme = {
-  name: "Moss Pink",
-  slug: "moss-pink",
-  type: "light",
-  isDefault: false,
-  colors: {
-    "primary": { "type": "solid", "value": rgba(0, 0, 0, 1) }, // prettier-ignore
-    "sideBar.background": { type: "solid", value: rgba(234, 157, 242, 1) },
-    "toolBar.background": { type: "solid", value: rgba(222, 125, 232, 1) },
-    "page.background": { type: "solid", value: rgba(227, 54, 245, 1) },
-    "statusBar.background": {
-      type: "gradient",
-      value: linearGradient(
-        "90deg",
-        [rgba(255, 0, 0, 1), 0],
-        [rgba(224, 0, 41, 1), 16],
-        [rgba(190, 0, 87, 1), 34],
-        [rgba(155, 0, 133, 1), 51],
-        [rgba(63, 0, 255, 1), 100]
-      ),
-    },
-    "windowsCloseButton.background": { type: "solid", value: rgba(196, 43, 28, 1) },
-    "windowControlsLinux.background": { type: "solid", value: rgba(218, 218, 218, 1) },
-    "windowControlsLinux.text": { type: "solid", value: rgba(61, 61, 61, 1) },
-    "windowControlsLinux.hoverBackground": { type: "solid", value: rgba(209, 209, 209, 1) },
-    "windowControlsLinux.activeBackground": { type: "solid", value: rgba(191, 191, 191, 1) },
-  },
-};
 
 const themes: Theme[] = [defaultDarkTheme, defaultLightTheme, pinkTheme];
 

--- a/tools/themegen/src/themes/moss-dark.ts
+++ b/tools/themegen/src/themes/moss-dark.ts
@@ -1,0 +1,22 @@
+// Default
+import { Theme } from "@repo/desktop-models";
+import { rgba } from "../color.ts";
+
+export const defaultDarkTheme: Theme = {
+  name: "Moss Dark Default",
+  slug: "moss-dark",
+  type: "dark",
+  isDefault: false,
+  colors: {
+    "primary": { "type": "solid", "value": rgba(255, 255, 255, 1) }, // prettier-ignore
+    "sideBar.background": { type: "solid", value: rgba(39, 39, 42, 1) },
+    "toolBar.background": { type: "solid", value: rgba(30, 32, 33, 1) },
+    "page.background": { type: "solid", value: rgba(22, 24, 25, 1) },
+    "statusBar.background": { type: "solid", value: "#0F62FE" },
+    "windowsCloseButton.background": { type: "solid", value: rgba(196, 43, 28, 1) },
+    "windowControlsLinux.background": { type: "solid", value: rgba(55, 55, 55, 1) },
+    "windowControlsLinux.text": { type: "solid", value: rgba(255, 255, 255, 1) },
+    "windowControlsLinux.hoverBackground": { type: "solid", value: rgba(66, 66, 66, 1) },
+    "windowControlsLinux.activeBackground": { type: "solid", value: rgba(86, 86, 86, 1) },
+  },
+};

--- a/tools/themegen/src/themes/moss-light.ts
+++ b/tools/themegen/src/themes/moss-light.ts
@@ -1,0 +1,21 @@
+import { Theme } from "@repo/desktop-models";
+import { rgba } from "../color.ts";
+
+export const defaultLightTheme: Theme = {
+  name: "Moss Light Default",
+  slug: "moss-light",
+  type: "light",
+  isDefault: true,
+  colors: {
+    "primary": { "type": "solid", "value": rgba(0, 0, 0, 1) }, // prettier-ignore
+    "sideBar.background": { type: "solid", value: rgba(244, 244, 245, 1) },
+    "toolBar.background": { type: "solid", value: rgba(224, 224, 224, 1) },
+    "page.background": { type: "solid", value: rgba(255, 255, 255, 1) },
+    "statusBar.background": { type: "solid", value: "#0F62FE" },
+    "windowsCloseButton.background": { type: "solid", value: rgba(196, 43, 28, 1) },
+    "windowControlsLinux.background": { type: "solid", value: rgba(218, 218, 218, 1) },
+    "windowControlsLinux.text": { type: "solid", value: rgba(61, 61, 61, 1) },
+    "windowControlsLinux.hoverBackground": { type: "solid", value: rgba(209, 209, 209, 1) },
+    "windowControlsLinux.activeBackground": { type: "solid", value: rgba(191, 191, 191, 1) },
+  },
+};

--- a/tools/themegen/src/themes/moss-pink.ts
+++ b/tools/themegen/src/themes/moss-pink.ts
@@ -1,0 +1,31 @@
+import { Theme } from "@repo/desktop-models";
+import { linearGradient, rgba } from "../color.ts";
+
+export const pinkTheme: Theme = {
+  name: "Moss Pink",
+  slug: "moss-pink",
+  type: "light",
+  isDefault: false,
+  colors: {
+    "primary": { "type": "solid", "value": rgba(0, 0, 0, 1) }, // prettier-ignore
+    "sideBar.background": { type: "solid", value: rgba(234, 157, 242, 1) },
+    "toolBar.background": { type: "solid", value: rgba(222, 125, 232, 1) },
+    "page.background": { type: "solid", value: rgba(227, 54, 245, 1) },
+    "statusBar.background": {
+      type: "gradient",
+      value: linearGradient(
+        "90deg",
+        [rgba(255, 0, 0, 1), 0],
+        [rgba(224, 0, 41, 1), 16],
+        [rgba(190, 0, 87, 1), 34],
+        [rgba(155, 0, 133, 1), 51],
+        [rgba(63, 0, 255, 1), 100]
+      ),
+    },
+    "windowsCloseButton.background": { type: "solid", value: rgba(196, 43, 28, 1) },
+    "windowControlsLinux.background": { type: "solid", value: rgba(218, 218, 218, 1) },
+    "windowControlsLinux.text": { type: "solid", value: rgba(61, 61, 61, 1) },
+    "windowControlsLinux.hoverBackground": { type: "solid", value: rgba(209, 209, 209, 1) },
+    "windowControlsLinux.activeBackground": { type: "solid", value: rgba(191, 191, 191, 1) },
+  },
+};


### PR DESCRIPTION
1. Write a makeshift install themes `make` script that works in Windows
2. Refactor the themegen tool so that it's more robust. Instead of writing raw strings, the values will be generated by functions that provide basic type checking and value range clamping.