### PR TITLE
chore(MOSSMVP-324): Terminate GitHub Action with a job failure on error

### DIFF
--- a/crates/moss-typebridge/Cargo.toml
+++ b/crates/moss-typebridge/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-serde = { version = "1.0.215", features = ["derive"] }
+serde.workspace = true
 moss_typebridge_macro.workspace = true

--- a/tools/xtask/src/tasks.rs
+++ b/tools/xtask/src/tasks.rs
@@ -3,7 +3,7 @@ pub mod rust_workspace_audit;
 
 use anyhow::Result;
 use futures::future::join_all;
-use std::{future::Future, mem};
+use std::{future::Future, mem, process};
 use tokio::task::JoinHandle;
 
 pub struct TaskRunner {
@@ -20,8 +20,14 @@ impl TaskRunner {
         for result in join_all(jobs).await {
             match result {
                 Ok(Ok(())) => {}
-                Ok(Err(e)) => error!("Error processing package: {e}"),
-                Err(e) => error!("Task panicked: {e}"),
+                Ok(Err(e)) => {
+                    error!("{}", e);
+                    process::exit(1);
+                }
+                Err(e) => {
+                    error!("{}", e);
+                    process::exit(1);
+                }
             }
         }
 

--- a/tools/xtask/src/tasks.rs
+++ b/tools/xtask/src/tasks.rs
@@ -3,7 +3,7 @@ pub mod rust_workspace_audit;
 
 use anyhow::Result;
 use futures::future::join_all;
-use std::{future::Future, mem, process};
+use std::{future::Future, mem};
 use tokio::task::JoinHandle;
 
 pub struct TaskRunner {
@@ -21,12 +21,10 @@ impl TaskRunner {
             match result {
                 Ok(Ok(())) => {}
                 Ok(Err(e)) => {
-                    error!("{}", e);
-                    process::exit(1);
+                    return Err(e);
                 }
                 Err(e) => {
-                    error!("{}", e);
-                    process::exit(1);
+                    return Err(e.into());
                 }
             }
         }


### PR DESCRIPTION
Now, when the `xtask` audit has any error, the GitHub Action job will be displayed as a failure.