### PR TITLE
perf(MOSS-335): Dependency cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,15 +910,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "csscolorparser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f9a16a848a7fb95dd47ce387ac1ee9a6df879ba784b815537fcd388a1a8288"
-dependencies = [
- "phf 0.11.2",
-]
-
-[[package]]
 name = "cssparser"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1032,14 +1023,9 @@ name = "desktop"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-task",
- "clap",
  "cocoa",
- "dashmap",
  "dirs",
  "fern",
- "flume",
- "futures",
  "hashbrown 0.15.0",
  "log",
  "macos-trampoline",
@@ -1050,7 +1036,6 @@ dependencies = [
  "moss_uikit",
  "objc",
  "once_cell",
- "parking_lot",
  "rand 0.8.5",
  "serde",
  "serde_json",
@@ -1064,7 +1049,6 @@ dependencies = [
  "tauri-plugin-os",
  "tauri-plugin-window-state",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -1340,18 +1324,6 @@ dependencies = [
  "borrow-or-share",
  "ref-cast",
  "serde",
-]
-
-[[package]]
-name = "flume"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "spin",
 ]
 
 [[package]]
@@ -1676,10 +1648,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2587,11 +2557,9 @@ name = "moss_desktop"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "csscolorparser",
  "dashmap",
  "hashbrown 0.15.0",
  "indexmap 2.7.0",
- "jsonschema",
  "moss_html",
  "moss_jsonlogic",
  "moss_jsonlogic_macro",
@@ -2631,10 +2599,7 @@ dependencies = [
 name = "moss_jsonlogic"
 version = "0.1.0"
 dependencies = [
- "anyhow",
- "arcstr",
  "moss_jsonlogic_macro",
- "moss_text",
  "serde",
  "serde_json",
  "thiserror 2.0.3",
@@ -2652,9 +2617,6 @@ dependencies = [
 [[package]]
 name = "moss_jsonschema"
 version = "0.1.0"
-dependencies = [
- "serde_json",
-]
 
 [[package]]
 name = "moss_text"
@@ -2689,7 +2651,6 @@ dependencies = [
 name = "moss_typebridge_macro"
 version = "0.1.0"
 dependencies = [
- "proc-macro2",
  "quote",
  "syn 2.0.90",
 ]
@@ -2722,15 +2683,6 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.15",
 ]
 
 [[package]]
@@ -4258,15 +4210,6 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
-]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
 ]
 
 [[package]]
@@ -6017,7 +5960,6 @@ dependencies = [
  "cargo_metadata 0.19.0",
  "clap",
  "futures",
- "parking_lot",
  "pathdiff",
  "serde",
  "smol",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,52 +70,29 @@ tauri = { version = "2.0.6", default-features = false, features = [
     "devtools",
     "macos-private-api",
 ] }
-libc = "0.2.155"
-fnv = "1.0.7"
 anyhow = "1.0"
-notify = "6.1.1"
 hashbrown = "0.15.0"
-arc-swap = "1.7.1"
 radix_trie = "0.2.1"
 parking_lot = "0.12.3"
-derive_more = "0.99.17"
 strum = "0.26"
-strum_macros = "0.26"
-lazy-regex = "3.3.0"
 dunce = "1.0.5"
 tokio = "1"
 smol = "2.0.0"
 futures = "0.3"
-async-task = "4.7.1"
-flume = "0.11.0"
 serde = "1.0"
 serde_json = "1.0"
 async-trait = "0.1"
 once_cell = "1.19"
-lazy_static = "1.4.0"
-surrealdb = "1.5.3"
 tracing = "0.1"
 tracing-subscriber = "0.3.18"
 tracing-appender = "0.2.3"
-slotmap = "1.0.7"
-rustc-hash = "2.1.0"
-parking = "2.2.1"
-waker-fn = "1.2.0"
-im = "15.1.0"
-smallvec = "1.13.2"
-dyn-clone = "1.0.17"
 clap = { version = "4.5.23", features = ["derive"] }
-
-hecs = "0.10.5"
-hecs-hierarchy = "0.12.1"
 
 fern = "0.7.0"
 rand = "0.8.5"
 log = "0.4.21"
 quote = "1.0"
 dirs = "5.0.1"
-csscolorparser = "0.7.0"
 jsonschema = { version = "0.26.1", default-features = false }
 
 os_info = { version = "3.9.0", default-features = false }
-gethostname = "0.5.0"

--- a/crates/moss-desktop/Cargo.toml
+++ b/crates/moss-desktop/Cargo.toml
@@ -17,9 +17,7 @@ indexmap = { workspace = true, features = ["serde"] }
 serde = { workspace = true, features = ["derive", "rc"] }
 ts-rs = { workspace = true, features = ["indexmap-impl", "serde-json-impl"] }
 once_cell.workspace = true
-csscolorparser.workspace = true
 serde_json.workspace = true
-jsonschema.workspace = true
 tauri.workspace = true
 parking_lot.workspace = true
 dashmap.workspace = true

--- a/crates/moss-jsonlogic/Cargo.toml
+++ b/crates/moss-jsonlogic/Cargo.toml
@@ -6,10 +6,7 @@ edition = "2021"
 [dependencies]
 serde_json.workspace = true
 serde.workspace = true
-arcstr.workspace = true
-moss_text.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-anyhow.workspace = true
 moss_jsonlogic_macro.workspace = true

--- a/crates/moss-theme/Cargo.toml
+++ b/crates/moss-theme/Cargo.toml
@@ -4,4 +4,3 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-serde_json.workspace = true

--- a/crates/moss-typebridge-macro/Cargo.toml
+++ b/crates/moss-typebridge-macro/Cargo.toml
@@ -9,4 +9,3 @@ proc-macro = true
 [dependencies]
 syn = { version = "2.0.90", features = ["full", "extra-traits"] }
 quote = "1.0"
-proc-macro2 = "1.0"

--- a/tools/xtask/Cargo.toml
+++ b/tools/xtask/Cargo.toml
@@ -18,4 +18,3 @@ smol.workspace = true
 tokio = { workspace = true, features = ["full"] }
 futures.workspace = true
 serde = { workspace = true, features = ["derive"] }
-parking_lot.workspace = true

--- a/view/desktop/bin/Cargo.toml
+++ b/view/desktop/bin/Cargo.toml
@@ -34,20 +34,13 @@ moss_uikit.workspace = true
 # workbench_service_configuration_tao.workspace = true
 # workbench_service_environment_tao.workspace = true
 
-futures.workspace = true
 anyhow.workspace = true
 once_cell.workspace = true
-parking_lot.workspace = true
-tracing.workspace = true
-flume.workspace = true
-async-task.workspace = true
 dirs.workspace = true
 log.workspace = true
 rand.workspace = true
 fern.workspace = true
 smol.workspace = true
-clap.workspace = true
-dashmap.workspace = true
 
 # surrealdb = { workspace = true, features = ["kv-rocksdb"] }
 tokio = { workspace = true, features = ["full", "macros", "signal"] }


### PR DESCRIPTION
While cargo-udeps doesn't reveal much, a manual review of the crate's and workspace's toml reveals that there are actually a decent number of unused dependencies after the refactoring. I also did a few profilings and auditing with `cargo tree` but have not found out any particular dependencies that need to be removed. The desktop app runs without any issue after the dependency cleanup, and there seems to be a further improvement in the compilation speed.