### PR TITLE
ci(deps): Fix the version specification for `rust-toolchain` Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@1.82
+        uses: dtolnay/rust-toolchain@master
         with:
           targets: ${{ matrix.platform.target }}
 
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@1.82
+        uses: dtolnay/rust-toolchain@master
 
       - name: Use Linux Apt Cache
         uses: awalsh128/cache-apt-pkgs-action@latest


### PR DESCRIPTION
The `rust-toolchain` repo contains various branches for yet-to-release rust toolchain versions, and dependabot will try to update it to the highest possible. This PR fixed it by specifying the version as the `master` branch.